### PR TITLE
feat: adds support for Laravel 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ vendor
 composer.phar
 composer.lock
 /.phpunit.result.cache
+.phpunit.cache
+.phpstan

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,20 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.2",
         "ext-libxml": "*",
         "ext-soap": "*",
-        "phpro/soap-client": "^1.1|^2.1",
-        "illuminate/support": "^8.0|^9.0|^10.0",
+        "phpro/soap-client": "^3.0",
+        "illuminate/support": "^9.0||^10.0||^11.0",
         "guzzlehttp/guzzle": "^7.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "laminas/laminas-code": "^4.0"
+        "phpunit/phpunit": "^9.0||^10.0||^11.0",
+        "laminas/laminas-code": "^4.0",
+        "mockery/mockery": "^1.6",
+        "phpstan/phpstan": "^1.11",
+        "phpstan/phpstan-deprecation-rules": "^1.2",
+        "orchestra/testbench": "^7.0||^8.0||^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,38 @@
+# if you get errors regarding undefined model properties/relations, ensure you have
+# added a type hint for the relation method and run
+#
+#   php artisan schema:dump
+#   php artisan schema:dump --database rsp
+#
+# afterwards.
+
+includes:
+    - ./vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+# the file can be found in the CRM
+# @TODO: extract it to a separate package
+# this is optional to provide an overview over the types of errors
+#services:
+#	errorFormatter.summary:
+#		class: App\PHPStan\SummaryErrorFormatter
+
+parameters:
+    parallel:
+        # this should be LESS than you total number of cores to prevent clogging your system
+        maximumNumberOfProcesses: 4
+    tmpDir: .phpstan
+    # put all "your" paths here
+    # this generally is "src" and "tests"
+    paths:
+        - src/
+        - tests/
+
+    editorUrl: 'phpstorm://open?file=%%file%%&line=%%line%%'
+
+    # Start with level 5 and gradually up this. target should be level 8 at least
+    level: 9
+
+    ignoreErrors:
+        #-
+        #    message: '#Undefined variable: \$this#'
+        #    path: tests/*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit bootstrap="tests/bootstrap.php">
-
-    <testsuites>
-        <testsuite name="Wortmann SOAP API Test Suite">
-            <directory>tests/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-html" target="./.tmp/report" lowUpperBound="35" highLowerBound="70"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.3/phpunit.xsd" cacheDirectory=".phpunit.cache">
+  <coverage>
+    <report>
+      <html outputDirectory="./.tmp/report" lowUpperBound="35" highLowerBound="70"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Wortmann SOAP API Test Suite">
+      <directory>tests/</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Bridge/Api.php
+++ b/src/Bridge/Api.php
@@ -25,8 +25,8 @@ class Api implements WortmannSoapApi
     }
 
     /**
-     * @param string $requestCls
-     * @param mixed ...$params
+	 * @param string $requestCls
+	 * @param mixed ...$params
      * @return ResultInterface
      * @throws ReflectionException
      * @throws XmlException

--- a/src/Client/ApiClassmap.php
+++ b/src/Client/ApiClassmap.php
@@ -3,39 +3,52 @@
 namespace Naugrim\WortmannSoapApi\Client;
 
 use Naugrim\WortmannSoapApi\Client\Type;
-use Soap\ExtSoapEngine\Configuration\ClassMap\ClassMap;
 use Soap\ExtSoapEngine\Configuration\ClassMap\ClassMapCollection;
+use Soap\ExtSoapEngine\Configuration\ClassMap\ClassMap;
 
 class ApiClassmap
 {
-
-    public static function getCollection() : ClassMapCollection
+    public static function getCollection() : \Soap\ExtSoapEngine\Configuration\ClassMap\ClassMapCollection
     {
         return new ClassMapCollection(
             new ClassMap('GetStockAndPriceInformationByProductId', Type\GetStockAndPriceInformationByProductId::class),
             new ClassMap('GetStockAndPriceInformationByProductIdResponse', Type\GetStockAndPriceInformationByProductIdResponse::class),
             new ClassMap('CustomerWebServiceProductInfoResponse', Type\CustomerWebServiceProductInfoResponse::class),
+            new ClassMap('ArrayOfProductInfoPackage', Type\ArrayOfProductInfoPackage::class),
             new ClassMap('ProductInfoPackage', Type\ProductInfoPackage::class),
             new ClassMap('GetStockAndPriceInformationByProductIds', Type\GetStockAndPriceInformationByProductIds::class),
+            new ClassMap('ArrayOfString', Type\ArrayOfString::class),
             new ClassMap('GetStockAndPriceInformationByProductIdsResponse', Type\GetStockAndPriceInformationByProductIdsResponse::class),
             new ClassMap('GetStockAndPriceInformationForForeignCustomerByProductIds', Type\GetStockAndPriceInformationForForeignCustomerByProductIds::class),
             new ClassMap('GetStockAndPriceInformationForForeignCustomerByProductIdsResponse', Type\GetStockAndPriceInformationForForeignCustomerByProductIdsResponse::class),
             new ClassMap('GetDriverLinks', Type\GetDriverLinks::class),
             new ClassMap('GetDriverLinksResponse', Type\GetDriverLinksResponse::class),
             new ClassMap('CustomerWebServiceDriverResponse', Type\CustomerWebServiceDriverResponse::class),
+            new ClassMap('ArrayOfTreeListEntry', Type\ArrayOfTreeListEntry::class),
             new ClassMap('TreeListEntry', Type\TreeListEntry::class),
             new ClassMap('SysInfoProduct', Type\SysInfoProduct::class),
+            new ClassMap('ArrayOfSysInfoDocument', Type\ArrayOfSysInfoDocument::class),
             new ClassMap('SysInfoDocument', Type\SysInfoDocument::class),
+            new ClassMap('ArrayOfSysInfoOperatingSystem', Type\ArrayOfSysInfoOperatingSystem::class),
             new ClassMap('SysInfoOperatingSystem', Type\SysInfoOperatingSystem::class),
+            new ClassMap('ArrayOfSysInfoLanguage', Type\ArrayOfSysInfoLanguage::class),
             new ClassMap('SysInfoLanguage', Type\SysInfoLanguage::class),
+            new ClassMap('ArrayOfSysInfoSubversion', Type\ArrayOfSysInfoSubversion::class),
+            new ClassMap('SysInfoSubversion', Type\SysInfoSubversion::class),
+            new ClassMap('ArrayOfSysInfoLink', Type\ArrayOfSysInfoLink::class),
             new ClassMap('SysInfoLink', Type\SysInfoLink::class),
+            new ClassMap('GetExtendedDriverLinks', Type\GetExtendedDriverLinks::class),
+            new ClassMap('GetExtendedDriverLinksResponse', Type\GetExtendedDriverLinksResponse::class),
             new ClassMap('GetServiceInfoByWarrantyEndingDate', Type\GetServiceInfoByWarrantyEndingDate::class),
             new ClassMap('GetServiceInfoByWarrantyEndingDateResponse', Type\GetServiceInfoByWarrantyEndingDateResponse::class),
             new ClassMap('CustomerWebServiceServiceInfoResponse', Type\CustomerWebServiceServiceInfoResponse::class),
+            new ClassMap('ArrayOfServiceInfo', Type\ArrayOfServiceInfo::class),
             new ClassMap('ServiceInfo', Type\ServiceInfo::class),
+            new ClassMap('ArrayOfComponent', Type\ArrayOfComponent::class),
             new ClassMap('Component', Type\Component::class),
             new ClassMap('GetServiceInfoBySerialNo', Type\GetServiceInfoBySerialNo::class),
             new ClassMap('GetServiceInfoBySerialNoResponse', Type\GetServiceInfoBySerialNoResponse::class),
         );
     }
 }
+

--- a/src/Client/ApiClient.php
+++ b/src/Client/ApiClient.php
@@ -2,93 +2,127 @@
 
 namespace Naugrim\WortmannSoapApi\Client;
 
+use Phpro\SoapClient\Caller\Caller;
 use Naugrim\WortmannSoapApi\Client\Type;
-use Naugrim\WortmannSoapApi\Client\Type\GetDriverLinks;
-use Naugrim\WortmannSoapApi\Client\Type\GetDriverLinksResponse;
-use Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoBySerialNo;
-use Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoBySerialNoResponse;
-use Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoByWarrantyEndingDate;
-use Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoByWarrantyEndingDateResponse;
-use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductId;
-use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdResponse;
-use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIds;
-use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdsResponse;
-use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationForForeignCustomerByProductIds;
-use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationForForeignCustomerByProductIdsResponse;
-use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 use Phpro\SoapClient\Exception\SoapException;
-use Phpro\SoapClient\Caller\Caller;
+use Phpro\SoapClient\Type\RequestInterface;
 
 class ApiClient
 {
     /**
      * @var Caller
      */
-    private $caller;
+    private Caller $caller;
 
-    public function __construct(Caller $caller)
+    public function __construct(\Phpro\SoapClient\Caller\Caller $caller)
     {
         $this->caller = $caller;
     }
 
     /**
-     * @param RequestInterface|GetStockAndPriceInformationByProductId $parameters
-     * @return ResultInterface|GetStockAndPriceInformationByProductIdResponse
+     * @param RequestInterface & Type\GetStockAndPriceInformationByProductId $parameters
+     * @return ResultInterface & Type\GetStockAndPriceInformationByProductIdResponse
      * @throws SoapException
      */
-    public function getStockAndPriceInformationByProductId(GetStockAndPriceInformationByProductId $parameters) : GetStockAndPriceInformationByProductIdResponse
+    public function getStockAndPriceInformationByProductId(\Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductId $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdResponse
     {
-        return ($this->caller)('GetStockAndPriceInformationByProductId', $parameters);
+        $response = ($this->caller)('GetStockAndPriceInformationByProductId', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
     }
 
     /**
-     * @param RequestInterface|GetStockAndPriceInformationByProductIds $parameters
-     * @return ResultInterface|GetStockAndPriceInformationByProductIdsResponse
+     * @param RequestInterface & Type\GetStockAndPriceInformationByProductIds $parameters
+     * @return ResultInterface & Type\GetStockAndPriceInformationByProductIdsResponse
      * @throws SoapException
      */
-    public function getStockAndPriceInformationByProductIds(GetStockAndPriceInformationByProductIds $parameters) : GetStockAndPriceInformationByProductIdsResponse
+    public function getStockAndPriceInformationByProductIds(\Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIds $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdsResponse
     {
-        return ($this->caller)('GetStockAndPriceInformationByProductIds', $parameters);
+        $response = ($this->caller)('GetStockAndPriceInformationByProductIds', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdsResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
     }
 
     /**
-     * @param RequestInterface|GetStockAndPriceInformationForForeignCustomerByProductIds $parameters
-     * @return ResultInterface|GetStockAndPriceInformationForForeignCustomerByProductIdsResponse
+     * @param RequestInterface & Type\GetStockAndPriceInformationForForeignCustomerByProductIds $parameters
+     * @return ResultInterface & Type\GetStockAndPriceInformationForForeignCustomerByProductIdsResponse
      * @throws SoapException
      */
-    public function getStockAndPriceInformationForForeignCustomerByProductIds(GetStockAndPriceInformationForForeignCustomerByProductIds $parameters) : GetStockAndPriceInformationForForeignCustomerByProductIdsResponse
+    public function getStockAndPriceInformationForForeignCustomerByProductIds(\Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationForForeignCustomerByProductIds $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationForForeignCustomerByProductIdsResponse
     {
-        return ($this->caller)('GetStockAndPriceInformationForForeignCustomerByProductIds', $parameters);
+        $response = ($this->caller)('GetStockAndPriceInformationForForeignCustomerByProductIds', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationForForeignCustomerByProductIdsResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
     }
 
     /**
-     * @param RequestInterface|GetDriverLinks $parameters
-     * @return ResultInterface|GetDriverLinksResponse
+     * @param RequestInterface & Type\GetDriverLinks $parameters
+     * @return ResultInterface & Type\GetDriverLinksResponse
      * @throws SoapException
      */
-    public function getDriverLinks(GetDriverLinks $parameters) : GetDriverLinksResponse
+    public function getDriverLinks(\Naugrim\WortmannSoapApi\Client\Type\GetDriverLinks $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetDriverLinksResponse
     {
-        return ($this->caller)('GetDriverLinks', $parameters);
+        $response = ($this->caller)('GetDriverLinks', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetDriverLinksResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
     }
 
     /**
-     * @param RequestInterface|GetServiceInfoByWarrantyEndingDate $parameters
-     * @return ResultInterface|GetServiceInfoByWarrantyEndingDateResponse
+     * @param RequestInterface & Type\GetExtendedDriverLinks $parameters
+     * @return ResultInterface & Type\GetExtendedDriverLinksResponse
      * @throws SoapException
      */
-    public function getServiceInfoByWarrantyEndingDate(GetServiceInfoByWarrantyEndingDate $parameters) : GetServiceInfoByWarrantyEndingDateResponse
+    public function getExtendedDriverLinks(\Naugrim\WortmannSoapApi\Client\Type\GetExtendedDriverLinks $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetExtendedDriverLinksResponse
     {
-        return ($this->caller)('GetServiceInfoByWarrantyEndingDate', $parameters);
+        $response = ($this->caller)('GetExtendedDriverLinks', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetExtendedDriverLinksResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
     }
 
     /**
-     * @param RequestInterface|GetServiceInfoBySerialNo $parameters
-     * @return ResultInterface|GetServiceInfoBySerialNoResponse
+     * @param RequestInterface & Type\GetServiceInfoByWarrantyEndingDate $parameters
+     * @return ResultInterface & Type\GetServiceInfoByWarrantyEndingDateResponse
      * @throws SoapException
      */
-    public function getServiceInfoBySerialNo(GetServiceInfoBySerialNo $parameters) : GetServiceInfoBySerialNoResponse
+    public function getServiceInfoByWarrantyEndingDate(\Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoByWarrantyEndingDate $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoByWarrantyEndingDateResponse
     {
-        return ($this->caller)('GetServiceInfoBySerialNo', $parameters);
+        $response = ($this->caller)('GetServiceInfoByWarrantyEndingDate', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoByWarrantyEndingDateResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
+    }
+
+    /**
+     * @param RequestInterface & Type\GetServiceInfoBySerialNo $parameters
+     * @return ResultInterface & Type\GetServiceInfoBySerialNoResponse
+     * @throws SoapException
+     */
+    public function getServiceInfoBySerialNo(\Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoBySerialNo $parameters) : \Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoBySerialNoResponse
+    {
+        $response = ($this->caller)('GetServiceInfoBySerialNo', $parameters);
+
+        \Psl\Type\instance_of(\Naugrim\WortmannSoapApi\Client\Type\GetServiceInfoBySerialNoResponse::class)->assert($response);
+        \Psl\Type\instance_of(\Phpro\SoapClient\Type\ResultInterface::class)->assert($response);
+
+        return $response;
     }
 }
+

--- a/src/Client/Type/ArrayOfComponent.php
+++ b/src/Client/Type/ArrayOfComponent.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfComponent
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\Component
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\Component $Component;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\Component
+     */
+    public function getComponent() : \Naugrim\WortmannSoapApi\Client\Type\Component
+    {
+        return $this->Component;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\Component $Component
+     * @return static
+     */
+    public function withComponent(\Naugrim\WortmannSoapApi\Client\Type\Component $Component) : static
+    {
+        $new = clone $this;
+        $new->Component = $Component;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfProductInfoPackage.php
+++ b/src/Client/Type/ArrayOfProductInfoPackage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfProductInfoPackage
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ProductInfoPackage
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ProductInfoPackage $ProductInfoPackage;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ProductInfoPackage
+     */
+    public function getProductInfoPackage() : \Naugrim\WortmannSoapApi\Client\Type\ProductInfoPackage
+    {
+        return $this->ProductInfoPackage;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ProductInfoPackage $ProductInfoPackage
+     * @return static
+     */
+    public function withProductInfoPackage(\Naugrim\WortmannSoapApi\Client\Type\ProductInfoPackage $ProductInfoPackage) : static
+    {
+        $new = clone $this;
+        $new->ProductInfoPackage = $ProductInfoPackage;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfServiceInfo.php
+++ b/src/Client/Type/ArrayOfServiceInfo.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfServiceInfo
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ServiceInfo
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ServiceInfo $ServiceInfo;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ServiceInfo
+     */
+    public function getServiceInfo() : \Naugrim\WortmannSoapApi\Client\Type\ServiceInfo
+    {
+        return $this->ServiceInfo;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ServiceInfo $ServiceInfo
+     * @return static
+     */
+    public function withServiceInfo(\Naugrim\WortmannSoapApi\Client\Type\ServiceInfo $ServiceInfo) : static
+    {
+        $new = clone $this;
+        $new->ServiceInfo = $ServiceInfo;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfString.php
+++ b/src/Client/Type/ArrayOfString.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfString
+{
+    /**
+     * @var string
+     */
+    private string $string;
+
+    /**
+     * @return string
+     */
+    public function getString() : string
+    {
+        return $this->string;
+    }
+
+    /**
+     * @param string $string
+     * @return static
+     */
+    public function withString(string $string) : static
+    {
+        $new = clone $this;
+        $new->string = $string;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfSysInfoDocument.php
+++ b/src/Client/Type/ArrayOfSysInfoDocument.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfSysInfoDocument
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\SysInfoDocument
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\SysInfoDocument $SysInfoDocument;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\SysInfoDocument
+     */
+    public function getSysInfoDocument() : \Naugrim\WortmannSoapApi\Client\Type\SysInfoDocument
+    {
+        return $this->SysInfoDocument;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\SysInfoDocument $SysInfoDocument
+     * @return static
+     */
+    public function withSysInfoDocument(\Naugrim\WortmannSoapApi\Client\Type\SysInfoDocument $SysInfoDocument) : static
+    {
+        $new = clone $this;
+        $new->SysInfoDocument = $SysInfoDocument;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfSysInfoLanguage.php
+++ b/src/Client/Type/ArrayOfSysInfoLanguage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfSysInfoLanguage
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\SysInfoLanguage
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\SysInfoLanguage $SysInfoLanguage;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\SysInfoLanguage
+     */
+    public function getSysInfoLanguage() : \Naugrim\WortmannSoapApi\Client\Type\SysInfoLanguage
+    {
+        return $this->SysInfoLanguage;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\SysInfoLanguage $SysInfoLanguage
+     * @return static
+     */
+    public function withSysInfoLanguage(\Naugrim\WortmannSoapApi\Client\Type\SysInfoLanguage $SysInfoLanguage) : static
+    {
+        $new = clone $this;
+        $new->SysInfoLanguage = $SysInfoLanguage;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfSysInfoLink.php
+++ b/src/Client/Type/ArrayOfSysInfoLink.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfSysInfoLink
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\SysInfoLink
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\SysInfoLink $SysInfoLink;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\SysInfoLink
+     */
+    public function getSysInfoLink() : \Naugrim\WortmannSoapApi\Client\Type\SysInfoLink
+    {
+        return $this->SysInfoLink;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\SysInfoLink $SysInfoLink
+     * @return static
+     */
+    public function withSysInfoLink(\Naugrim\WortmannSoapApi\Client\Type\SysInfoLink $SysInfoLink) : static
+    {
+        $new = clone $this;
+        $new->SysInfoLink = $SysInfoLink;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfSysInfoOperatingSystem.php
+++ b/src/Client/Type/ArrayOfSysInfoOperatingSystem.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfSysInfoOperatingSystem
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\SysInfoOperatingSystem
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\SysInfoOperatingSystem $SysInfoOperatingSystem;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\SysInfoOperatingSystem
+     */
+    public function getSysInfoOperatingSystem() : \Naugrim\WortmannSoapApi\Client\Type\SysInfoOperatingSystem
+    {
+        return $this->SysInfoOperatingSystem;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\SysInfoOperatingSystem $SysInfoOperatingSystem
+     * @return static
+     */
+    public function withSysInfoOperatingSystem(\Naugrim\WortmannSoapApi\Client\Type\SysInfoOperatingSystem $SysInfoOperatingSystem) : static
+    {
+        $new = clone $this;
+        $new->SysInfoOperatingSystem = $SysInfoOperatingSystem;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfSysInfoSubversion.php
+++ b/src/Client/Type/ArrayOfSysInfoSubversion.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfSysInfoSubversion
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\SysInfoSubversion
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\SysInfoSubversion $SysInfoSubversion;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\SysInfoSubversion
+     */
+    public function getSysInfoSubversion() : \Naugrim\WortmannSoapApi\Client\Type\SysInfoSubversion
+    {
+        return $this->SysInfoSubversion;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\SysInfoSubversion $SysInfoSubversion
+     * @return static
+     */
+    public function withSysInfoSubversion(\Naugrim\WortmannSoapApi\Client\Type\SysInfoSubversion $SysInfoSubversion) : static
+    {
+        $new = clone $this;
+        $new->SysInfoSubversion = $SysInfoSubversion;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/ArrayOfTreeListEntry.php
+++ b/src/Client/Type/ArrayOfTreeListEntry.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class ArrayOfTreeListEntry
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\TreeListEntry
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\TreeListEntry $TreeListEntry;
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\TreeListEntry
+     */
+    public function getTreeListEntry() : \Naugrim\WortmannSoapApi\Client\Type\TreeListEntry
+    {
+        return $this->TreeListEntry;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\TreeListEntry $TreeListEntry
+     * @return static
+     */
+    public function withTreeListEntry(\Naugrim\WortmannSoapApi\Client\Type\TreeListEntry $TreeListEntry) : static
+    {
+        $new = clone $this;
+        $new->TreeListEntry = $TreeListEntry;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/Component.php
+++ b/src/Client/Type/Component.php
@@ -4,96 +4,104 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 class Component
 {
-
     /**
      * @var string
      */
-    private $ItemNo;
+    private string $ItemNo;
 
     /**
      * @var int
      */
-    private $LineNo;
+    private int $LineNo;
 
     /**
      * @var string
      */
-    private $Description;
+    private string $Description;
 
     /**
      * @var string
      */
-    private $SerialNo;
+    private string $SerialNo;
 
     /**
      * @return string
      */
-    public function getItemNo(): string
+    public function getItemNo() : string
     {
         return $this->ItemNo;
     }
 
     /**
      * @param string $ItemNo
-     * @return Component
+     * @return static
      */
-    public function setItemNo(string $ItemNo): Component
+    public function withItemNo(string $ItemNo) : static
     {
-        $this->ItemNo = $ItemNo;
-        return $this;
+        $new = clone $this;
+        $new->ItemNo = $ItemNo;
+
+        return $new;
     }
 
     /**
      * @return int
      */
-    public function getLineNo(): int
+    public function getLineNo() : int
     {
         return $this->LineNo;
     }
 
     /**
      * @param int $LineNo
-     * @return Component
+     * @return static
      */
-    public function setLineNo(int $LineNo): Component
+    public function withLineNo(int $LineNo) : static
     {
-        $this->LineNo = $LineNo;
-        return $this;
+        $new = clone $this;
+        $new->LineNo = $LineNo;
+
+        return $new;
     }
 
     /**
      * @return string
      */
-    public function getDescription(): string
+    public function getDescription() : string
     {
         return $this->Description;
     }
 
     /**
      * @param string $Description
-     * @return Component
+     * @return static
      */
-    public function setDescription(string $Description): Component
+    public function withDescription(string $Description) : static
     {
-        $this->Description = $Description;
-        return $this;
+        $new = clone $this;
+        $new->Description = $Description;
+
+        return $new;
     }
 
     /**
      * @return string
      */
-    public function getSerialNo(): string
+    public function getSerialNo() : string
     {
         return $this->SerialNo;
     }
 
     /**
      * @param string $SerialNo
-     * @return Component
+     * @return static
      */
-    public function setSerialNo(string $SerialNo): Component
+    public function withSerialNo(string $SerialNo) : static
     {
-        $this->SerialNo = $SerialNo;
-        return $this;
+        $new = clone $this;
+        $new->SerialNo = $SerialNo;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/CustomerWebServiceDriverResponse.php
+++ b/src/Client/Type/CustomerWebServiceDriverResponse.php
@@ -2,56 +2,83 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class CustomerWebServiceDriverResponse implements ResultInterface, ApiResponseContract
+class CustomerWebServiceDriverResponse implements ResultInterface
 {
-
     /**
      * @var bool
      */
-    private $Success;
+    private bool $Success;
 
     /**
      * @var string
      */
-    private $ErrorMesssage;
+    private string $ErrorMesssage;
 
     /**
-     * @var array
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfTreeListEntry
      */
-    private $Drivers;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfTreeListEntry $Drivers;
 
     /**
      * @return bool
      */
-    public function getSuccess()
+    public function getSuccess() : bool
     {
         return $this->Success;
     }
 
     /**
+     * @param bool $Success
+     * @return static
+     */
+    public function withSuccess(bool $Success) : static
+    {
+        $new = clone $this;
+        $new->Success = $Success;
+
+        return $new;
+    }
+
+    /**
      * @return string
      */
-    public function getErrorMesssage()
+    public function getErrorMesssage() : string
     {
         return $this->ErrorMesssage;
     }
 
     /**
-     * @return array
+     * @param string $ErrorMesssage
+     * @return static
      */
-    public function getDrivers()
+    public function withErrorMesssage(string $ErrorMesssage) : static
+    {
+        $new = clone $this;
+        $new->ErrorMesssage = $ErrorMesssage;
+
+        return $new;
+    }
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfTreeListEntry
+     */
+    public function getDrivers() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfTreeListEntry
     {
         return $this->Drivers;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfTreeListEntry $Drivers
+     * @return static
+     */
+    public function withDrivers(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfTreeListEntry $Drivers) : static
     {
-        if (!$this->getDrivers()) {
-            return [];
-        }
-        return current($this->getDrivers());
+        $new = clone $this;
+        $new->Drivers = $Drivers;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/CustomerWebServiceProductInfoResponse.php
+++ b/src/Client/Type/CustomerWebServiceProductInfoResponse.php
@@ -2,55 +2,83 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class CustomerWebServiceProductInfoResponse implements ResultInterface, ApiResponseContract
+class CustomerWebServiceProductInfoResponse implements ResultInterface
 {
-
     /**
      * @var bool
      */
-    private $Success;
+    private bool $Success;
 
     /**
      * @var string
      */
-    private $ErrorMesssage;
+    private string $ErrorMesssage;
 
     /**
-     * @var array
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfProductInfoPackage
      */
-    private $ProductInfoPackages;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfProductInfoPackage $ProductInfoPackages;
 
     /**
      * @return bool
      */
-    public function getSuccess()
+    public function getSuccess() : bool
     {
         return $this->Success;
     }
 
     /**
+     * @param bool $Success
+     * @return static
+     */
+    public function withSuccess(bool $Success) : static
+    {
+        $new = clone $this;
+        $new->Success = $Success;
+
+        return $new;
+    }
+
+    /**
      * @return string
      */
-    public function getErrorMesssage()
+    public function getErrorMesssage() : string
     {
         return $this->ErrorMesssage;
     }
+
     /**
-     * @return array
+     * @param string $ErrorMesssage
+     * @return static
      */
-    public function getProductInfoPackages()
+    public function withErrorMesssage(string $ErrorMesssage) : static
+    {
+        $new = clone $this;
+        $new->ErrorMesssage = $ErrorMesssage;
+
+        return $new;
+    }
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfProductInfoPackage
+     */
+    public function getProductInfoPackages() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfProductInfoPackage
     {
         return $this->ProductInfoPackages;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfProductInfoPackage $ProductInfoPackages
+     * @return static
+     */
+    public function withProductInfoPackages(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfProductInfoPackage $ProductInfoPackages) : static
     {
-        if (!$this->getProductInfoPackages()) {
-            return [];
-        }
-        return current($this->getProductInfoPackages());
+        $new = clone $this;
+        $new->ProductInfoPackages = $ProductInfoPackages;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/CustomerWebServiceServiceInfoResponse.php
+++ b/src/Client/Type/CustomerWebServiceServiceInfoResponse.php
@@ -2,56 +2,83 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class CustomerWebServiceServiceInfoResponse implements ResultInterface, ApiResponseContract
+class CustomerWebServiceServiceInfoResponse implements ResultInterface
 {
-
     /**
      * @var bool
      */
-    private $Success;
+    private bool $Success;
 
     /**
      * @var string
      */
-    private $ErrorMesssage;
+    private string $ErrorMesssage;
 
     /**
-     * @var array
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfServiceInfo
      */
-    private $ServiceInfos;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfServiceInfo $ServiceInfos;
 
     /**
      * @return bool
      */
-    public function getSuccess()
+    public function getSuccess() : bool
     {
         return $this->Success;
     }
 
     /**
+     * @param bool $Success
+     * @return static
+     */
+    public function withSuccess(bool $Success) : static
+    {
+        $new = clone $this;
+        $new->Success = $Success;
+
+        return $new;
+    }
+
+    /**
      * @return string
      */
-    public function getErrorMesssage()
+    public function getErrorMesssage() : string
     {
         return $this->ErrorMesssage;
     }
 
     /**
-     * @return array
+     * @param string $ErrorMesssage
+     * @return static
      */
-    public function getServiceInfos()
+    public function withErrorMesssage(string $ErrorMesssage) : static
+    {
+        $new = clone $this;
+        $new->ErrorMesssage = $ErrorMesssage;
+
+        return $new;
+    }
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfServiceInfo
+     */
+    public function getServiceInfos() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfServiceInfo
     {
         return $this->ServiceInfos;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfServiceInfo $ServiceInfos
+     * @return static
+     */
+    public function withServiceInfos(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfServiceInfo $ServiceInfos) : static
     {
-        if (!$this->getServiceInfos()) {
-            return [];
-        }
-        return current($this->getServiceInfos());
+        $new = clone $this;
+        $new->ServiceInfos = $ServiceInfos;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/GetDriverLinks.php
+++ b/src/Client/Type/GetDriverLinks.php
@@ -6,18 +6,17 @@ use Phpro\SoapClient\Type\RequestInterface;
 
 class GetDriverLinks implements RequestInterface
 {
-
     /**
      * @var string
      */
-    private $SearchTerm;
+    private string $SearchTerm;
 
     /**
      * Constructor
      *
-     * @var string $SearchTerm
+     * @param string $SearchTerm
      */
-    public function __construct($SearchTerm)
+    public function __construct(string $SearchTerm)
     {
         $this->SearchTerm = $SearchTerm;
     }
@@ -25,16 +24,16 @@ class GetDriverLinks implements RequestInterface
     /**
      * @return string
      */
-    public function getSearchTerm()
+    public function getSearchTerm() : string
     {
         return $this->SearchTerm;
     }
 
     /**
      * @param string $SearchTerm
-     * @return GetDriverLinks
+     * @return static
      */
-    public function withSearchTerm($SearchTerm)
+    public function withSearchTerm(string $SearchTerm) : static
     {
         $new = clone $this;
         $new->SearchTerm = $SearchTerm;
@@ -42,3 +41,4 @@ class GetDriverLinks implements RequestInterface
         return $new;
     }
 }
+

--- a/src/Client/Type/GetDriverLinksResponse.php
+++ b/src/Client/Type/GetDriverLinksResponse.php
@@ -2,37 +2,44 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
+use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class GetDriverLinksResponse implements ResultInterface, ApiResponseContract
+class GetDriverLinksResponse implements RequestInterface, ResultInterface
 {
-
     /**
-     * @var CustomerWebServiceDriverResponse
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse
      */
-    private $GetDriverLinksResult;
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetDriverLinksResult;
 
     /**
      * Constructor
      *
-     * @var CustomerWebServiceDriverResponse $GetDriverLinksResult
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetDriverLinksResult
      */
-    public function __construct($GetDriverLinksResult)
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetDriverLinksResult)
     {
         $this->GetDriverLinksResult = $GetDriverLinksResult;
     }
 
     /**
-     * @return CustomerWebServiceDriverResponse
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse
      */
-    public function getGetDriverLinksResult()
+    public function getGetDriverLinksResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse
     {
         return $this->GetDriverLinksResult;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetDriverLinksResult
+     * @return static
+     */
+    public function withGetDriverLinksResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetDriverLinksResult) : static
     {
-        return $this->getGetDriverLinksResult()->entry();
+        $new = clone $this;
+        $new->GetDriverLinksResult = $GetDriverLinksResult;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/GetExtendedDriverLinks.php
+++ b/src/Client/Type/GetExtendedDriverLinks.php
@@ -4,7 +4,7 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 use Phpro\SoapClient\Type\RequestInterface;
 
-class GetServiceInfoByWarrantyEndingDate implements RequestInterface
+class GetExtendedDriverLinks implements RequestInterface
 {
     /**
      * @var string
@@ -17,22 +17,22 @@ class GetServiceInfoByWarrantyEndingDate implements RequestInterface
     private string $PasswordHash;
 
     /**
-     * @var \DateTimeInterface
+     * @var string
      */
-    private \DateTimeInterface $WarrantyEndingDate;
+    private string $SearchTerm;
 
     /**
      * Constructor
      *
      * @param string $Username
      * @param string $PasswordHash
-     * @param \DateTimeInterface $WarrantyEndingDate
+     * @param string $SearchTerm
      */
-    public function __construct(string $Username, string $PasswordHash, \DateTimeInterface $WarrantyEndingDate)
+    public function __construct(string $Username, string $PasswordHash, string $SearchTerm)
     {
         $this->Username = $Username;
         $this->PasswordHash = $PasswordHash;
-        $this->WarrantyEndingDate = $WarrantyEndingDate;
+        $this->SearchTerm = $SearchTerm;
     }
 
     /**
@@ -76,21 +76,21 @@ class GetServiceInfoByWarrantyEndingDate implements RequestInterface
     }
 
     /**
-     * @return \DateTimeInterface
+     * @return string
      */
-    public function getWarrantyEndingDate() : \DateTimeInterface
+    public function getSearchTerm() : string
     {
-        return $this->WarrantyEndingDate;
+        return $this->SearchTerm;
     }
 
     /**
-     * @param \DateTimeInterface $WarrantyEndingDate
+     * @param string $SearchTerm
      * @return static
      */
-    public function withWarrantyEndingDate(\DateTimeInterface $WarrantyEndingDate) : static
+    public function withSearchTerm(string $SearchTerm) : static
     {
         $new = clone $this;
-        $new->WarrantyEndingDate = $WarrantyEndingDate;
+        $new->SearchTerm = $SearchTerm;
 
         return $new;
     }

--- a/src/Client/Type/GetExtendedDriverLinksResponse.php
+++ b/src/Client/Type/GetExtendedDriverLinksResponse.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+use Phpro\SoapClient\Type\RequestInterface;
+use Phpro\SoapClient\Type\ResultInterface;
+
+class GetExtendedDriverLinksResponse implements RequestInterface, ResultInterface
+{
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetExtendedDriverLinksResult;
+
+    /**
+     * Constructor
+     *
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetExtendedDriverLinksResult
+     */
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetExtendedDriverLinksResult)
+    {
+        $this->GetExtendedDriverLinksResult = $GetExtendedDriverLinksResult;
+    }
+
+    /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse
+     */
+    public function getGetExtendedDriverLinksResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse
+    {
+        return $this->GetExtendedDriverLinksResult;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetExtendedDriverLinksResult
+     * @return static
+     */
+    public function withGetExtendedDriverLinksResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceDriverResponse $GetExtendedDriverLinksResult) : static
+    {
+        $new = clone $this;
+        $new->GetExtendedDriverLinksResult = $GetExtendedDriverLinksResult;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/GetServiceInfoBySerialNo.php
+++ b/src/Client/Type/GetServiceInfoBySerialNo.php
@@ -6,30 +6,29 @@ use Phpro\SoapClient\Type\RequestInterface;
 
 class GetServiceInfoBySerialNo implements RequestInterface
 {
+    /**
+     * @var string
+     */
+    private string $Username;
 
     /**
      * @var string
      */
-    private $Username;
+    private string $PasswordHash;
 
     /**
      * @var string
      */
-    private $PasswordHash;
-
-    /**
-     * @var string
-     */
-    private $SerialNo;
+    private string $SerialNo;
 
     /**
      * Constructor
      *
-     * @var string $Username
-     * @var string $PasswordHash
-     * @var string $SerialNo
+     * @param string $Username
+     * @param string $PasswordHash
+     * @param string $SerialNo
      */
-    public function __construct($Username, $PasswordHash, $SerialNo)
+    public function __construct(string $Username, string $PasswordHash, string $SerialNo)
     {
         $this->Username = $Username;
         $this->PasswordHash = $PasswordHash;
@@ -39,16 +38,16 @@ class GetServiceInfoBySerialNo implements RequestInterface
     /**
      * @return string
      */
-    public function getUsername()
+    public function getUsername() : string
     {
         return $this->Username;
     }
 
     /**
      * @param string $Username
-     * @return GetServiceInfoBySerialNo
+     * @return static
      */
-    public function withUsername($Username)
+    public function withUsername(string $Username) : static
     {
         $new = clone $this;
         $new->Username = $Username;
@@ -59,16 +58,16 @@ class GetServiceInfoBySerialNo implements RequestInterface
     /**
      * @return string
      */
-    public function getPasswordHash()
+    public function getPasswordHash() : string
     {
         return $this->PasswordHash;
     }
 
     /**
      * @param string $PasswordHash
-     * @return GetServiceInfoBySerialNo
+     * @return static
      */
-    public function withPasswordHash($PasswordHash)
+    public function withPasswordHash(string $PasswordHash) : static
     {
         $new = clone $this;
         $new->PasswordHash = $PasswordHash;
@@ -79,16 +78,16 @@ class GetServiceInfoBySerialNo implements RequestInterface
     /**
      * @return string
      */
-    public function getSerialNo()
+    public function getSerialNo() : string
     {
         return $this->SerialNo;
     }
 
     /**
      * @param string $SerialNo
-     * @return GetServiceInfoBySerialNo
+     * @return static
      */
-    public function withSerialNo($SerialNo)
+    public function withSerialNo(string $SerialNo) : static
     {
         $new = clone $this;
         $new->SerialNo = $SerialNo;
@@ -96,3 +95,4 @@ class GetServiceInfoBySerialNo implements RequestInterface
         return $new;
     }
 }
+

--- a/src/Client/Type/GetServiceInfoBySerialNoResponse.php
+++ b/src/Client/Type/GetServiceInfoBySerialNoResponse.php
@@ -2,38 +2,44 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
 use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class GetServiceInfoBySerialNoResponse implements ResultInterface, ApiResponseContract
+class GetServiceInfoBySerialNoResponse implements RequestInterface, ResultInterface
 {
-
     /**
-     * @var CustomerWebServiceServiceInfoResponse
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse
      */
-    private $GetServiceInfoBySerialNoResult;
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoBySerialNoResult;
 
     /**
      * Constructor
      *
-     * @var CustomerWebServiceServiceInfoResponse $item
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoBySerialNoResult
      */
-    public function __construct($item)
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoBySerialNoResult)
     {
-        $this->GetServiceInfoBySerialNoResult = $item;
+        $this->GetServiceInfoBySerialNoResult = $GetServiceInfoBySerialNoResult;
     }
 
     /**
-     * @return CustomerWebServiceServiceInfoResponse
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse
      */
-    public function getGetServiceInfoBySerialNoResult()
+    public function getGetServiceInfoBySerialNoResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse
     {
         return $this->GetServiceInfoBySerialNoResult;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoBySerialNoResult
+     * @return static
+     */
+    public function withGetServiceInfoBySerialNoResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoBySerialNoResult) : static
     {
-        return $this->getGetServiceInfoBySerialNoResult()->entry();
+        $new = clone $this;
+        $new->GetServiceInfoBySerialNoResult = $GetServiceInfoBySerialNoResult;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/GetServiceInfoByWarrantyEndingDateResponse.php
+++ b/src/Client/Type/GetServiceInfoByWarrantyEndingDateResponse.php
@@ -2,37 +2,44 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
+use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class GetServiceInfoByWarrantyEndingDateResponse implements ResultInterface, ApiResponseContract
+class GetServiceInfoByWarrantyEndingDateResponse implements RequestInterface, ResultInterface
 {
-
     /**
-     * @var CustomerWebServiceServiceInfoResponse
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse
      */
-    private $GetServiceInfoByWarrantyEndingDateResult;
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoByWarrantyEndingDateResult;
 
     /**
      * Constructor
      *
-     * @var CustomerWebServiceServiceInfoResponse $item
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoByWarrantyEndingDateResult
      */
-    public function __construct($item)
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoByWarrantyEndingDateResult)
     {
-        $this->GetServiceInfoByWarrantyEndingDateResult = $item;
+        $this->GetServiceInfoByWarrantyEndingDateResult = $GetServiceInfoByWarrantyEndingDateResult;
     }
 
     /**
-     * @return CustomerWebServiceServiceInfoResponse
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse
      */
-    public function getGetServiceInfoByWarrantyEndingDateResult()
+    public function getGetServiceInfoByWarrantyEndingDateResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse
     {
         return $this->GetServiceInfoByWarrantyEndingDateResult;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoByWarrantyEndingDateResult
+     * @return static
+     */
+    public function withGetServiceInfoByWarrantyEndingDateResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceServiceInfoResponse $GetServiceInfoByWarrantyEndingDateResult) : static
     {
-        return $this->getGetServiceInfoByWarrantyEndingDateResult()->entry();
+        $new = clone $this;
+        $new->GetServiceInfoByWarrantyEndingDateResult = $GetServiceInfoByWarrantyEndingDateResult;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/GetStockAndPriceInformationByProductId.php
+++ b/src/Client/Type/GetStockAndPriceInformationByProductId.php
@@ -6,30 +6,29 @@ use Phpro\SoapClient\Type\RequestInterface;
 
 class GetStockAndPriceInformationByProductId implements RequestInterface
 {
+    /**
+     * @var string
+     */
+    private string $Username;
 
     /**
      * @var string
      */
-    private $Username;
+    private string $PasswordHash;
 
     /**
      * @var string
      */
-    private $PasswordHash;
-
-    /**
-     * @var string
-     */
-    private $ProductId;
+    private string $ProductId;
 
     /**
      * Constructor
      *
-     * @var string $Username
-     * @var string $PasswordHash
-     * @var string $ProductId
+     * @param string $Username
+     * @param string $PasswordHash
+     * @param string $ProductId
      */
-    public function __construct($Username, $PasswordHash, $ProductId)
+    public function __construct(string $Username, string $PasswordHash, string $ProductId)
     {
         $this->Username = $Username;
         $this->PasswordHash = $PasswordHash;
@@ -39,16 +38,16 @@ class GetStockAndPriceInformationByProductId implements RequestInterface
     /**
      * @return string
      */
-    public function getUsername()
+    public function getUsername() : string
     {
         return $this->Username;
     }
 
     /**
      * @param string $Username
-     * @return GetStockAndPriceInformationByProductId
+     * @return static
      */
-    public function withUsername($Username)
+    public function withUsername(string $Username) : static
     {
         $new = clone $this;
         $new->Username = $Username;
@@ -59,16 +58,16 @@ class GetStockAndPriceInformationByProductId implements RequestInterface
     /**
      * @return string
      */
-    public function getPasswordHash()
+    public function getPasswordHash() : string
     {
         return $this->PasswordHash;
     }
 
     /**
      * @param string $PasswordHash
-     * @return GetStockAndPriceInformationByProductId
+     * @return static
      */
-    public function withPasswordHash($PasswordHash)
+    public function withPasswordHash(string $PasswordHash) : static
     {
         $new = clone $this;
         $new->PasswordHash = $PasswordHash;
@@ -79,16 +78,16 @@ class GetStockAndPriceInformationByProductId implements RequestInterface
     /**
      * @return string
      */
-    public function getProductId()
+    public function getProductId() : string
     {
         return $this->ProductId;
     }
 
     /**
      * @param string $ProductId
-     * @return GetStockAndPriceInformationByProductId
+     * @return static
      */
-    public function withProductId($ProductId)
+    public function withProductId(string $ProductId) : static
     {
         $new = clone $this;
         $new->ProductId = $ProductId;
@@ -96,3 +95,4 @@ class GetStockAndPriceInformationByProductId implements RequestInterface
         return $new;
     }
 }
+

--- a/src/Client/Type/GetStockAndPriceInformationByProductIdResponse.php
+++ b/src/Client/Type/GetStockAndPriceInformationByProductIdResponse.php
@@ -2,38 +2,44 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
 use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class GetStockAndPriceInformationByProductIdResponse implements ResultInterface, ApiResponseContract
+class GetStockAndPriceInformationByProductIdResponse implements RequestInterface, ResultInterface
 {
-
     /**
-     * @var CustomerWebServiceProductInfoResponse
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
      */
-    private $GetStockAndPriceInformationByProductIdResult;
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdResult;
 
     /**
      * Constructor
      *
-     * @var CustomerWebServiceProductInfoResponse $item
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdResult
      */
-    public function __construct($item)
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdResult)
     {
-        $this->GetStockAndPriceInformationByProductIdResult = $item;
+        $this->GetStockAndPriceInformationByProductIdResult = $GetStockAndPriceInformationByProductIdResult;
     }
 
     /**
-     * @return CustomerWebServiceProductInfoResponse
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
      */
-    public function getGetStockAndPriceInformationByProductIdResult()
+    public function getGetStockAndPriceInformationByProductIdResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
     {
         return $this->GetStockAndPriceInformationByProductIdResult;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdResult
+     * @return static
+     */
+    public function withGetStockAndPriceInformationByProductIdResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdResult) : static
     {
-        return $this->getGetStockAndPriceInformationByProductIdResult()->entry();
+        $new = clone $this;
+        $new->GetStockAndPriceInformationByProductIdResult = $GetStockAndPriceInformationByProductIdResult;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/GetStockAndPriceInformationByProductIds.php
+++ b/src/Client/Type/GetStockAndPriceInformationByProductIds.php
@@ -6,30 +6,29 @@ use Phpro\SoapClient\Type\RequestInterface;
 
 class GetStockAndPriceInformationByProductIds implements RequestInterface
 {
+    /**
+     * @var string
+     */
+    private string $Username;
 
     /**
      * @var string
      */
-    private $Username;
+    private string $PasswordHash;
 
     /**
-     * @var string
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString
      */
-    private $PasswordHash;
-
-    /**
-     * @var array
-     */
-    private $ProductIds;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds;
 
     /**
      * Constructor
      *
-     * @var string $Username
-     * @var string $PasswordHash
-     * @var array $ProductIds
+     * @param string $Username
+     * @param string $PasswordHash
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds
      */
-    public function __construct($Username, $PasswordHash, $ProductIds)
+    public function __construct(string $Username, string $PasswordHash, \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds)
     {
         $this->Username = $Username;
         $this->PasswordHash = $PasswordHash;
@@ -39,16 +38,16 @@ class GetStockAndPriceInformationByProductIds implements RequestInterface
     /**
      * @return string
      */
-    public function getUsername()
+    public function getUsername() : string
     {
         return $this->Username;
     }
 
     /**
      * @param string $Username
-     * @return GetStockAndPriceInformationByProductIds
+     * @return static
      */
-    public function withUsername($Username)
+    public function withUsername(string $Username) : static
     {
         $new = clone $this;
         $new->Username = $Username;
@@ -59,16 +58,16 @@ class GetStockAndPriceInformationByProductIds implements RequestInterface
     /**
      * @return string
      */
-    public function getPasswordHash()
+    public function getPasswordHash() : string
     {
         return $this->PasswordHash;
     }
 
     /**
      * @param string $PasswordHash
-     * @return GetStockAndPriceInformationByProductIds
+     * @return static
      */
-    public function withPasswordHash($PasswordHash)
+    public function withPasswordHash(string $PasswordHash) : static
     {
         $new = clone $this;
         $new->PasswordHash = $PasswordHash;
@@ -77,18 +76,18 @@ class GetStockAndPriceInformationByProductIds implements RequestInterface
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString
      */
-    public function getProductIds()
+    public function getProductIds() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString
     {
         return $this->ProductIds;
     }
 
     /**
-     * @param array $ProductIds
-     * @return GetStockAndPriceInformationByProductIds
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds
+     * @return static
      */
-    public function withProductIds($ProductIds)
+    public function withProductIds(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds) : static
     {
         $new = clone $this;
         $new->ProductIds = $ProductIds;
@@ -96,3 +95,4 @@ class GetStockAndPriceInformationByProductIds implements RequestInterface
         return $new;
     }
 }
+

--- a/src/Client/Type/GetStockAndPriceInformationByProductIdsResponse.php
+++ b/src/Client/Type/GetStockAndPriceInformationByProductIdsResponse.php
@@ -2,37 +2,44 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
+use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class GetStockAndPriceInformationByProductIdsResponse implements ResultInterface, ApiResponseContract
+class GetStockAndPriceInformationByProductIdsResponse implements RequestInterface, ResultInterface
 {
-
     /**
-     * @var CustomerWebServiceProductInfoResponse
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
      */
-    private $GetStockAndPriceInformationByProductIdsResult;
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdsResult;
 
     /**
      * Constructor
      *
-     * @var CustomerWebServiceProductInfoResponse $item
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdsResult
      */
-    public function __construct($item)
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdsResult)
     {
-        $this->GetStockAndPriceInformationByProductIdsResult = $item;
+        $this->GetStockAndPriceInformationByProductIdsResult = $GetStockAndPriceInformationByProductIdsResult;
     }
 
     /**
-     * @return CustomerWebServiceProductInfoResponse
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
      */
-    public function getGetStockAndPriceInformationByProductIdsResult()
+    public function getGetStockAndPriceInformationByProductIdsResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
     {
         return $this->GetStockAndPriceInformationByProductIdsResult;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdsResult
+     * @return static
+     */
+    public function withGetStockAndPriceInformationByProductIdsResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationByProductIdsResult) : static
     {
-        return $this->getGetStockAndPriceInformationByProductIdsResult()->entry();
+        $new = clone $this;
+        $new->GetStockAndPriceInformationByProductIdsResult = $GetStockAndPriceInformationByProductIdsResult;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/GetStockAndPriceInformationForForeignCustomerByProductIds.php
+++ b/src/Client/Type/GetStockAndPriceInformationForForeignCustomerByProductIds.php
@@ -6,36 +6,35 @@ use Phpro\SoapClient\Type\RequestInterface;
 
 class GetStockAndPriceInformationForForeignCustomerByProductIds implements RequestInterface
 {
+    /**
+     * @var string
+     */
+    private string $Username;
 
     /**
      * @var string
      */
-    private $Username;
+    private string $PasswordHash;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds;
 
     /**
      * @var string
      */
-    private $PasswordHash;
-
-    /**
-     * @var array
-     */
-    private $ProductIds;
-
-    /**
-     * @var string
-     */
-    private $ForeignCustomerNumber;
+    private string $ForeignCustomerNumber;
 
     /**
      * Constructor
      *
-     * @var string $Username
-     * @var string $PasswordHash
-     * @var array $ProductIds
-     * @var string $ForeignCustomerNumber
+     * @param string $Username
+     * @param string $PasswordHash
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds
+     * @param string $ForeignCustomerNumber
      */
-    public function __construct($Username, $PasswordHash, $ProductIds, $ForeignCustomerNumber)
+    public function __construct(string $Username, string $PasswordHash, \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds, string $ForeignCustomerNumber)
     {
         $this->Username = $Username;
         $this->PasswordHash = $PasswordHash;
@@ -46,16 +45,16 @@ class GetStockAndPriceInformationForForeignCustomerByProductIds implements Reque
     /**
      * @return string
      */
-    public function getUsername()
+    public function getUsername() : string
     {
         return $this->Username;
     }
 
     /**
      * @param string $Username
-     * @return GetStockAndPriceInformationForForeignCustomerByProductIds
+     * @return static
      */
-    public function withUsername($Username)
+    public function withUsername(string $Username) : static
     {
         $new = clone $this;
         $new->Username = $Username;
@@ -66,16 +65,16 @@ class GetStockAndPriceInformationForForeignCustomerByProductIds implements Reque
     /**
      * @return string
      */
-    public function getPasswordHash()
+    public function getPasswordHash() : string
     {
         return $this->PasswordHash;
     }
 
     /**
      * @param string $PasswordHash
-     * @return GetStockAndPriceInformationForForeignCustomerByProductIds
+     * @return static
      */
-    public function withPasswordHash($PasswordHash)
+    public function withPasswordHash(string $PasswordHash) : static
     {
         $new = clone $this;
         $new->PasswordHash = $PasswordHash;
@@ -84,18 +83,18 @@ class GetStockAndPriceInformationForForeignCustomerByProductIds implements Reque
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString
      */
-    public function getProductIds()
+    public function getProductIds() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString
     {
         return $this->ProductIds;
     }
 
     /**
-     * @param array $ProductIds
-     * @return GetStockAndPriceInformationForForeignCustomerByProductIds
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds
+     * @return static
      */
-    public function withProductIds($ProductIds)
+    public function withProductIds(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfString $ProductIds) : static
     {
         $new = clone $this;
         $new->ProductIds = $ProductIds;
@@ -106,16 +105,16 @@ class GetStockAndPriceInformationForForeignCustomerByProductIds implements Reque
     /**
      * @return string
      */
-    public function getForeignCustomerNumber()
+    public function getForeignCustomerNumber() : string
     {
         return $this->ForeignCustomerNumber;
     }
 
     /**
      * @param string $ForeignCustomerNumber
-     * @return GetStockAndPriceInformationForForeignCustomerByProductIds
+     * @return static
      */
-    public function withForeignCustomerNumber($ForeignCustomerNumber)
+    public function withForeignCustomerNumber(string $ForeignCustomerNumber) : static
     {
         $new = clone $this;
         $new->ForeignCustomerNumber = $ForeignCustomerNumber;
@@ -123,3 +122,4 @@ class GetStockAndPriceInformationForForeignCustomerByProductIds implements Reque
         return $new;
     }
 }
+

--- a/src/Client/Type/GetStockAndPriceInformationForForeignCustomerByProductIdsResponse.php
+++ b/src/Client/Type/GetStockAndPriceInformationForForeignCustomerByProductIdsResponse.php
@@ -2,37 +2,44 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use Naugrim\WortmannSoapApi\Client\Contracts\ApiResponseContract;
+use Phpro\SoapClient\Type\RequestInterface;
 use Phpro\SoapClient\Type\ResultInterface;
 
-class GetStockAndPriceInformationForForeignCustomerByProductIdsResponse implements ResultInterface, ApiResponseContract
+class GetStockAndPriceInformationForForeignCustomerByProductIdsResponse implements RequestInterface, ResultInterface
 {
-
     /**
-     * @var CustomerWebServiceProductInfoResponse
+     * @var \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
      */
-    private $GetStockAndPriceInformationForForeignCustomerByProductIdsResult;
+    private \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationForForeignCustomerByProductIdsResult;
 
     /**
      * Constructor
      *
-     * @var CustomerWebServiceProductInfoResponse $item
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationForForeignCustomerByProductIdsResult
      */
-    public function __construct($item)
+    public function __construct(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationForForeignCustomerByProductIdsResult)
     {
-        $this->GetStockAndPriceInformationForForeignCustomerByProductIdsResult = $item;
+        $this->GetStockAndPriceInformationForForeignCustomerByProductIdsResult = $GetStockAndPriceInformationForForeignCustomerByProductIdsResult;
     }
 
     /**
-     * @return CustomerWebServiceProductInfoResponse
+     * @return \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
      */
-    public function getGetStockAndPriceInformationForForeignCustomerByProductIdsResult()
+    public function getGetStockAndPriceInformationForForeignCustomerByProductIdsResult() : \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse
     {
         return $this->GetStockAndPriceInformationForForeignCustomerByProductIdsResult;
     }
 
-    public function entry(): array
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationForForeignCustomerByProductIdsResult
+     * @return static
+     */
+    public function withGetStockAndPriceInformationForForeignCustomerByProductIdsResult(\Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse $GetStockAndPriceInformationForForeignCustomerByProductIdsResult) : static
     {
-        return $this->getGetStockAndPriceInformationForForeignCustomerByProductIdsResult()->entry();
+        $new = clone $this;
+        $new->GetStockAndPriceInformationForForeignCustomerByProductIdsResult = $GetStockAndPriceInformationForForeignCustomerByProductIdsResult;
+
+        return $new;
     }
 }
+

--- a/src/Client/Type/ProductInfoPackage.php
+++ b/src/Client/Type/ProductInfoPackage.php
@@ -2,89 +2,86 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use DateTimeInterface;
-
 class ProductInfoPackage
 {
+    /**
+     * @var string
+     */
+    private string $ProductId;
+
+    /**
+     * @var float
+     */
+    private float $PriceB2B;
+
+    /**
+     * @var float
+     */
+    private float $PriceB2BDiscounted;
+
+    /**
+     * @var float
+     */
+    private float $PriceB2BDiscountPercent;
+
+    /**
+     * @var float
+     */
+    private float $PriceB2BDiscountAmount;
+
+    /**
+     * @var float
+     */
+    private float $PriceB2CinclVAT;
+
+    /**
+     * @var float
+     */
+    private float $PriceB2CexclVAT;
 
     /**
      * @var string
      */
-    private $ProductId;
+    private string $Currency;
 
     /**
      * @var float
      */
-    private $PriceB2B;
-
-    /**
-     * @var float
-     */
-    private $PriceB2BDiscounted;
-
-    /**
-     * @var float
-     */
-    private $PriceB2BDiscountPercent;
-
-    /**
-     * @var float
-     */
-    private $PriceB2BDiscountAmount;
-
-    /**
-     * @var float
-     */
-    private $PriceB2CinclVAT;
-
-    /**
-     * @var float
-     */
-    private $PriceB2CexclVAT;
+    private float $vatRate;
 
     /**
      * @var string
      */
-    private $Currency;
-
-    /**
-     * @var float
-     */
-    private $vatRate;
-
-    /**
-     * @var string
-     */
-    private $vatCountry;
+    private string $vatCountry;
 
     /**
      * @var int
      */
-    private $Stock;
+    private int $Stock;
 
     /**
-     * @var DateTimeInterface
+     * @var \DateTimeInterface
      */
-    private $StockNextDelivery;
+    private \DateTimeInterface $StockNextDelivery;
 
     /**
      * @var int
      */
-    private $StockNextDeliveryAccessVolume;
+    private int $StockNextDeliveryAccessVolume;
 
     /**
      * @return string
      */
-    public function getProductId()
+    public function getProductId() : string
     {
         return $this->ProductId;
     }
 
     /**
      * @param string $ProductId
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withProductId($ProductId)
+    public function withProductId(string $ProductId) : static
     {
         $new = clone $this;
         $new->ProductId = $ProductId;
@@ -95,16 +92,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getPriceB2B()
+    public function getPriceB2B() : float
     {
         return $this->PriceB2B;
     }
 
     /**
      * @param float $PriceB2B
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withPriceB2B($PriceB2B)
+    public function withPriceB2B(float $PriceB2B) : static
     {
         $new = clone $this;
         $new->PriceB2B = $PriceB2B;
@@ -115,16 +112,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getPriceB2BDiscounted()
+    public function getPriceB2BDiscounted() : float
     {
         return $this->PriceB2BDiscounted;
     }
 
     /**
      * @param float $PriceB2BDiscounted
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withPriceB2BDiscounted($PriceB2BDiscounted)
+    public function withPriceB2BDiscounted(float $PriceB2BDiscounted) : static
     {
         $new = clone $this;
         $new->PriceB2BDiscounted = $PriceB2BDiscounted;
@@ -135,16 +132,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getPriceB2BDiscountPercent()
+    public function getPriceB2BDiscountPercent() : float
     {
         return $this->PriceB2BDiscountPercent;
     }
 
     /**
      * @param float $PriceB2BDiscountPercent
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withPriceB2BDiscountPercent($PriceB2BDiscountPercent)
+    public function withPriceB2BDiscountPercent(float $PriceB2BDiscountPercent) : static
     {
         $new = clone $this;
         $new->PriceB2BDiscountPercent = $PriceB2BDiscountPercent;
@@ -155,16 +152,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getPriceB2BDiscountAmount()
+    public function getPriceB2BDiscountAmount() : float
     {
         return $this->PriceB2BDiscountAmount;
     }
 
     /**
      * @param float $PriceB2BDiscountAmount
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withPriceB2BDiscountAmount($PriceB2BDiscountAmount)
+    public function withPriceB2BDiscountAmount(float $PriceB2BDiscountAmount) : static
     {
         $new = clone $this;
         $new->PriceB2BDiscountAmount = $PriceB2BDiscountAmount;
@@ -175,16 +172,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getPriceB2CinclVAT()
+    public function getPriceB2CinclVAT() : float
     {
         return $this->PriceB2CinclVAT;
     }
 
     /**
      * @param float $PriceB2CinclVAT
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withPriceB2CinclVAT($PriceB2CinclVAT)
+    public function withPriceB2CinclVAT(float $PriceB2CinclVAT) : static
     {
         $new = clone $this;
         $new->PriceB2CinclVAT = $PriceB2CinclVAT;
@@ -195,16 +192,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getPriceB2CexclVAT()
+    public function getPriceB2CexclVAT() : float
     {
         return $this->PriceB2CexclVAT;
     }
 
     /**
      * @param float $PriceB2CexclVAT
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withPriceB2CexclVAT($PriceB2CexclVAT)
+    public function withPriceB2CexclVAT(float $PriceB2CexclVAT) : static
     {
         $new = clone $this;
         $new->PriceB2CexclVAT = $PriceB2CexclVAT;
@@ -215,16 +212,16 @@ class ProductInfoPackage
     /**
      * @return string
      */
-    public function getCurrency()
+    public function getCurrency() : string
     {
         return $this->Currency;
     }
 
     /**
      * @param string $Currency
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withCurrency($Currency)
+    public function withCurrency(string $Currency) : static
     {
         $new = clone $this;
         $new->Currency = $Currency;
@@ -235,16 +232,16 @@ class ProductInfoPackage
     /**
      * @return float
      */
-    public function getVatRate()
+    public function getVatRate() : float
     {
         return $this->vatRate;
     }
 
     /**
      * @param float $vatRate
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withVatRate($vatRate)
+    public function withVatRate(float $vatRate) : static
     {
         $new = clone $this;
         $new->vatRate = $vatRate;
@@ -255,16 +252,16 @@ class ProductInfoPackage
     /**
      * @return string
      */
-    public function getVatCountry()
+    public function getVatCountry() : string
     {
         return $this->vatCountry;
     }
 
     /**
      * @param string $vatCountry
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withVatCountry($vatCountry)
+    public function withVatCountry(string $vatCountry) : static
     {
         $new = clone $this;
         $new->vatCountry = $vatCountry;
@@ -275,16 +272,16 @@ class ProductInfoPackage
     /**
      * @return int
      */
-    public function getStock()
+    public function getStock() : int
     {
         return $this->Stock;
     }
 
     /**
      * @param int $Stock
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withStock($Stock)
+    public function withStock(int $Stock) : static
     {
         $new = clone $this;
         $new->Stock = $Stock;
@@ -293,18 +290,18 @@ class ProductInfoPackage
     }
 
     /**
-     * @return DateTimeInterface
+     * @return \DateTimeInterface
      */
-    public function getStockNextDelivery()
+    public function getStockNextDelivery() : \DateTimeInterface
     {
         return $this->StockNextDelivery;
     }
 
     /**
-     * @param DateTimeInterface $StockNextDelivery
-     * @return ProductInfoPackage
+     * @param \DateTimeInterface $StockNextDelivery
+     * @return static
      */
-    public function withStockNextDelivery($StockNextDelivery)
+    public function withStockNextDelivery(\DateTimeInterface $StockNextDelivery) : static
     {
         $new = clone $this;
         $new->StockNextDelivery = $StockNextDelivery;
@@ -315,16 +312,16 @@ class ProductInfoPackage
     /**
      * @return int
      */
-    public function getStockNextDeliveryAccessVolume()
+    public function getStockNextDeliveryAccessVolume() : int
     {
         return $this->StockNextDeliveryAccessVolume;
     }
 
     /**
      * @param int $StockNextDeliveryAccessVolume
-     * @return ProductInfoPackage
+     * @return static
      */
-    public function withStockNextDeliveryAccessVolume($StockNextDeliveryAccessVolume)
+    public function withStockNextDeliveryAccessVolume(int $StockNextDeliveryAccessVolume) : static
     {
         $new = clone $this;
         $new->StockNextDeliveryAccessVolume = $StockNextDeliveryAccessVolume;
@@ -332,3 +329,4 @@ class ProductInfoPackage
         return $new;
     }
 }
+

--- a/src/Client/Type/ServiceInfo.php
+++ b/src/Client/Type/ServiceInfo.php
@@ -4,125 +4,124 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 class ServiceInfo
 {
+    /**
+     * @var string
+     */
+    private string $ServiceItemNo;
 
     /**
      * @var string
      */
-    private $ServiceItemNo;
+    private string $ServiceItemDescription;
 
     /**
      * @var string
      */
-    private $ServiceItemDescription;
+    private string $ServiceItemDescription2;
 
     /**
      * @var string
      */
-    private $ServiceItemDescription2;
+    private string $ItemNo;
 
     /**
      * @var string
      */
-    private $ItemNo;
+    private string $ItemDescription;
 
     /**
      * @var string
      */
-    private $ItemDescription;
+    private string $CustomerNo;
 
     /**
      * @var string
      */
-    private $CustomerNo;
+    private string $SerialNo;
 
     /**
      * @var string
      */
-    private $SerialNo;
+    private string $InvoiceNo;
 
     /**
      * @var string
      */
-    private $InvoiceNo;
+    private string $InvoicePostingDate;
 
     /**
      * @var string
      */
-    private $InvoicePostingDate;
+    private string $ShipmentNo;
 
     /**
      * @var string
      */
-    private $ShipmentNo;
+    private string $ShipmentPostingDate;
 
     /**
      * @var string
      */
-    private $ShipmentPostingDate;
+    private string $ExternalDocumentNo;
 
     /**
      * @var string
      */
-    private $ExternalDocumentNo;
-
-    /**
-     * @var string
-     */
-    private $Commission;
+    private string $Commission;
 
     /**
      * @var float
      */
-    private $InvoiceUnitPrice;
+    private float $InvoiceUnitPrice;
 
     /**
      * @var string
      */
-    private $InvoiceCurrencyCode;
+    private string $InvoiceCurrencyCode;
 
     /**
      * @var string
      */
-    private $InvoiceLineCommission;
+    private string $InvoiceLineCommission;
 
     /**
      * @var string
      */
-    private $WarrantyCode;
+    private string $WarrantyCode;
 
     /**
      * @var string
      */
-    private $WarrantyDescription;
+    private string $WarrantyDescription;
 
     /**
      * @var string
      */
-    private $WarrantyStartingDate;
+    private string $WarrantyStartingDate;
 
     /**
      * @var string
      */
-    private $WarrantyEndingDate;
+    private string $WarrantyEndingDate;
 
     /**
-     * @var array
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfComponent
      */
-    private $Components;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfComponent $Components;
 
     /**
      * @return string
      */
-    public function getServiceItemNo()
+    public function getServiceItemNo() : string
     {
         return $this->ServiceItemNo;
     }
 
     /**
      * @param string $ServiceItemNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withServiceItemNo($ServiceItemNo)
+    public function withServiceItemNo(string $ServiceItemNo) : static
     {
         $new = clone $this;
         $new->ServiceItemNo = $ServiceItemNo;
@@ -133,16 +132,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getServiceItemDescription()
+    public function getServiceItemDescription() : string
     {
         return $this->ServiceItemDescription;
     }
 
     /**
      * @param string $ServiceItemDescription
-     * @return ServiceInfo
+     * @return static
      */
-    public function withServiceItemDescription($ServiceItemDescription)
+    public function withServiceItemDescription(string $ServiceItemDescription) : static
     {
         $new = clone $this;
         $new->ServiceItemDescription = $ServiceItemDescription;
@@ -153,16 +152,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getServiceItemDescription2()
+    public function getServiceItemDescription2() : string
     {
         return $this->ServiceItemDescription2;
     }
 
     /**
      * @param string $ServiceItemDescription2
-     * @return ServiceInfo
+     * @return static
      */
-    public function withServiceItemDescription2($ServiceItemDescription2)
+    public function withServiceItemDescription2(string $ServiceItemDescription2) : static
     {
         $new = clone $this;
         $new->ServiceItemDescription2 = $ServiceItemDescription2;
@@ -173,16 +172,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getItemNo()
+    public function getItemNo() : string
     {
         return $this->ItemNo;
     }
 
     /**
      * @param string $ItemNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withItemNo($ItemNo)
+    public function withItemNo(string $ItemNo) : static
     {
         $new = clone $this;
         $new->ItemNo = $ItemNo;
@@ -193,16 +192,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getItemDescription()
+    public function getItemDescription() : string
     {
         return $this->ItemDescription;
     }
 
     /**
      * @param string $ItemDescription
-     * @return ServiceInfo
+     * @return static
      */
-    public function withItemDescription($ItemDescription)
+    public function withItemDescription(string $ItemDescription) : static
     {
         $new = clone $this;
         $new->ItemDescription = $ItemDescription;
@@ -213,16 +212,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getCustomerNo()
+    public function getCustomerNo() : string
     {
         return $this->CustomerNo;
     }
 
     /**
      * @param string $CustomerNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withCustomerNo($CustomerNo)
+    public function withCustomerNo(string $CustomerNo) : static
     {
         $new = clone $this;
         $new->CustomerNo = $CustomerNo;
@@ -233,16 +232,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getSerialNo()
+    public function getSerialNo() : string
     {
         return $this->SerialNo;
     }
 
     /**
      * @param string $SerialNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withSerialNo($SerialNo)
+    public function withSerialNo(string $SerialNo) : static
     {
         $new = clone $this;
         $new->SerialNo = $SerialNo;
@@ -253,16 +252,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getInvoiceNo()
+    public function getInvoiceNo() : string
     {
         return $this->InvoiceNo;
     }
 
     /**
      * @param string $InvoiceNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withInvoiceNo($InvoiceNo)
+    public function withInvoiceNo(string $InvoiceNo) : static
     {
         $new = clone $this;
         $new->InvoiceNo = $InvoiceNo;
@@ -273,16 +272,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getInvoicePostingDate()
+    public function getInvoicePostingDate() : string
     {
         return $this->InvoicePostingDate;
     }
 
     /**
      * @param string $InvoicePostingDate
-     * @return ServiceInfo
+     * @return static
      */
-    public function withInvoicePostingDate($InvoicePostingDate)
+    public function withInvoicePostingDate(string $InvoicePostingDate) : static
     {
         $new = clone $this;
         $new->InvoicePostingDate = $InvoicePostingDate;
@@ -293,16 +292,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getShipmentNo()
+    public function getShipmentNo() : string
     {
         return $this->ShipmentNo;
     }
 
     /**
      * @param string $ShipmentNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withShipmentNo($ShipmentNo)
+    public function withShipmentNo(string $ShipmentNo) : static
     {
         $new = clone $this;
         $new->ShipmentNo = $ShipmentNo;
@@ -313,16 +312,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getShipmentPostingDate()
+    public function getShipmentPostingDate() : string
     {
         return $this->ShipmentPostingDate;
     }
 
     /**
      * @param string $ShipmentPostingDate
-     * @return ServiceInfo
+     * @return static
      */
-    public function withShipmentPostingDate($ShipmentPostingDate)
+    public function withShipmentPostingDate(string $ShipmentPostingDate) : static
     {
         $new = clone $this;
         $new->ShipmentPostingDate = $ShipmentPostingDate;
@@ -333,16 +332,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getExternalDocumentNo()
+    public function getExternalDocumentNo() : string
     {
         return $this->ExternalDocumentNo;
     }
 
     /**
      * @param string $ExternalDocumentNo
-     * @return ServiceInfo
+     * @return static
      */
-    public function withExternalDocumentNo($ExternalDocumentNo)
+    public function withExternalDocumentNo(string $ExternalDocumentNo) : static
     {
         $new = clone $this;
         $new->ExternalDocumentNo = $ExternalDocumentNo;
@@ -353,16 +352,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getCommission()
+    public function getCommission() : string
     {
         return $this->Commission;
     }
 
     /**
      * @param string $Commission
-     * @return ServiceInfo
+     * @return static
      */
-    public function withCommission($Commission)
+    public function withCommission(string $Commission) : static
     {
         $new = clone $this;
         $new->Commission = $Commission;
@@ -373,16 +372,16 @@ class ServiceInfo
     /**
      * @return float
      */
-    public function getInvoiceUnitPrice()
+    public function getInvoiceUnitPrice() : float
     {
         return $this->InvoiceUnitPrice;
     }
 
     /**
      * @param float $InvoiceUnitPrice
-     * @return ServiceInfo
+     * @return static
      */
-    public function withInvoiceUnitPrice($InvoiceUnitPrice)
+    public function withInvoiceUnitPrice(float $InvoiceUnitPrice) : static
     {
         $new = clone $this;
         $new->InvoiceUnitPrice = $InvoiceUnitPrice;
@@ -393,16 +392,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getInvoiceCurrencyCode()
+    public function getInvoiceCurrencyCode() : string
     {
         return $this->InvoiceCurrencyCode;
     }
 
     /**
      * @param string $InvoiceCurrencyCode
-     * @return ServiceInfo
+     * @return static
      */
-    public function withInvoiceCurrencyCode($InvoiceCurrencyCode)
+    public function withInvoiceCurrencyCode(string $InvoiceCurrencyCode) : static
     {
         $new = clone $this;
         $new->InvoiceCurrencyCode = $InvoiceCurrencyCode;
@@ -413,16 +412,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getInvoiceLineCommission()
+    public function getInvoiceLineCommission() : string
     {
         return $this->InvoiceLineCommission;
     }
 
     /**
      * @param string $InvoiceLineCommission
-     * @return ServiceInfo
+     * @return static
      */
-    public function withInvoiceLineCommission($InvoiceLineCommission)
+    public function withInvoiceLineCommission(string $InvoiceLineCommission) : static
     {
         $new = clone $this;
         $new->InvoiceLineCommission = $InvoiceLineCommission;
@@ -433,16 +432,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getWarrantyCode()
+    public function getWarrantyCode() : string
     {
         return $this->WarrantyCode;
     }
 
     /**
      * @param string $WarrantyCode
-     * @return ServiceInfo
+     * @return static
      */
-    public function withWarrantyCode($WarrantyCode)
+    public function withWarrantyCode(string $WarrantyCode) : static
     {
         $new = clone $this;
         $new->WarrantyCode = $WarrantyCode;
@@ -453,16 +452,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getWarrantyDescription()
+    public function getWarrantyDescription() : string
     {
         return $this->WarrantyDescription;
     }
 
     /**
      * @param string $WarrantyDescription
-     * @return ServiceInfo
+     * @return static
      */
-    public function withWarrantyDescription($WarrantyDescription)
+    public function withWarrantyDescription(string $WarrantyDescription) : static
     {
         $new = clone $this;
         $new->WarrantyDescription = $WarrantyDescription;
@@ -473,16 +472,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getWarrantyStartingDate()
+    public function getWarrantyStartingDate() : string
     {
         return $this->WarrantyStartingDate;
     }
 
     /**
      * @param string $WarrantyStartingDate
-     * @return ServiceInfo
+     * @return static
      */
-    public function withWarrantyStartingDate($WarrantyStartingDate)
+    public function withWarrantyStartingDate(string $WarrantyStartingDate) : static
     {
         $new = clone $this;
         $new->WarrantyStartingDate = $WarrantyStartingDate;
@@ -493,16 +492,16 @@ class ServiceInfo
     /**
      * @return string
      */
-    public function getWarrantyEndingDate()
+    public function getWarrantyEndingDate() : string
     {
         return $this->WarrantyEndingDate;
     }
 
     /**
      * @param string $WarrantyEndingDate
-     * @return ServiceInfo
+     * @return static
      */
-    public function withWarrantyEndingDate($WarrantyEndingDate)
+    public function withWarrantyEndingDate(string $WarrantyEndingDate) : static
     {
         $new = clone $this;
         $new->WarrantyEndingDate = $WarrantyEndingDate;
@@ -511,18 +510,18 @@ class ServiceInfo
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfComponent
      */
-    public function getComponents()
+    public function getComponents() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfComponent
     {
         return $this->Components;
     }
 
     /**
-     * @param array $Components
-     * @return ServiceInfo
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfComponent $Components
+     * @return static
      */
-    public function withComponents($Components)
+    public function withComponents(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfComponent $Components) : static
     {
         $new = clone $this;
         $new->Components = $Components;
@@ -530,3 +529,4 @@ class ServiceInfo
         return $new;
     }
 }
+

--- a/src/Client/Type/SysInfoDocument.php
+++ b/src/Client/Type/SysInfoDocument.php
@@ -2,124 +2,126 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use DateTimeInterface;
-
 class SysInfoDocument
 {
+    /**
+     * @var int
+     */
+    private int $Id;
+
+    /**
+     * @var string
+     */
+    private string $NavID;
 
     /**
      * @var int
      */
-    private $Id;
+    private int $ParentId;
 
     /**
      * @var string
      */
-    private $NavID;
+    private string $OldId;
+
+    /**
+     * @var string
+     */
+    private string $Description;
 
     /**
      * @var int
      */
-    private $ParentId;
+    private int $Type;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem $OperatingSystems;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage $Languages;
+
+    /**
+     * @var \DateTimeInterface
+     */
+    private \DateTimeInterface $DocumentDate;
 
     /**
      * @var string
      */
-    private $OldId;
+    private string $Version;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion $Subversions;
 
     /**
      * @var string
      */
-    private $Description;
+    private string $MatchCode;
 
     /**
      * @var int
      */
-    private $Type;
-
-    /**
-     * @var array
-     */
-    private $OperatingSystems;
-
-    /**
-     * @var array
-     */
-    private $Languages;
-
-    /**
-     * @var DateTimeInterface
-     */
-    private $DocumentDate;
-
-    /**
-     * @var string
-     */
-    private $Version;
-
-    /**
-     * @var string
-     */
-    private $MatchCode;
-
-    /**
-     * @var int
-     */
-    private $Release;
+    private int $Release;
 
     /**
      * @var bool
      */
-    private $RegisteredDownload;
+    private bool $RegisteredDownload;
 
     /**
      * @var bool
      */
-    private $FindOnlyViaSerialNo;
+    private bool $FindOnlyViaSerialNo;
 
     /**
      * @var string
      */
-    private $LongDescription;
+    private string $LongDescription;
 
     /**
-     * @var DateTimeInterface
+     * @var \DateTimeInterface
      */
-    private $MinDate;
+    private \DateTimeInterface $MinDate;
 
     /**
-     * @var DateTimeInterface
+     * @var \DateTimeInterface
      */
-    private $MaxDate;
+    private \DateTimeInterface $MaxDate;
 
     /**
-     * @var array
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink
      */
-    private $Links;
-
-    /**
-     * @var string
-     */
-    private $FaultText;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink $Links;
 
     /**
      * @var string
      */
-    private $SolutionText;
+    private string $FaultText;
+
+    /**
+     * @var string
+     */
+    private string $SolutionText;
 
     /**
      * @return int
      */
-    public function getId()
+    public function getId() : int
     {
         return $this->Id;
     }
 
     /**
      * @param int $Id
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withId($Id)
+    public function withId(int $Id) : static
     {
         $new = clone $this;
         $new->Id = $Id;
@@ -130,16 +132,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getNavID()
+    public function getNavID() : string
     {
         return $this->NavID;
     }
 
     /**
      * @param string $NavID
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withNavID($NavID)
+    public function withNavID(string $NavID) : static
     {
         $new = clone $this;
         $new->NavID = $NavID;
@@ -150,16 +152,16 @@ class SysInfoDocument
     /**
      * @return int
      */
-    public function getParentId()
+    public function getParentId() : int
     {
         return $this->ParentId;
     }
 
     /**
      * @param int $ParentId
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withParentId($ParentId)
+    public function withParentId(int $ParentId) : static
     {
         $new = clone $this;
         $new->ParentId = $ParentId;
@@ -170,16 +172,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getOldId()
+    public function getOldId() : string
     {
         return $this->OldId;
     }
 
     /**
      * @param string $OldId
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withOldId($OldId)
+    public function withOldId(string $OldId) : static
     {
         $new = clone $this;
         $new->OldId = $OldId;
@@ -190,16 +192,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->Description;
     }
 
     /**
      * @param string $Description
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withDescription($Description)
+    public function withDescription(string $Description) : static
     {
         $new = clone $this;
         $new->Description = $Description;
@@ -210,16 +212,16 @@ class SysInfoDocument
     /**
      * @return int
      */
-    public function getType()
+    public function getType() : int
     {
         return $this->Type;
     }
 
     /**
      * @param int $Type
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withType($Type)
+    public function withType(int $Type) : static
     {
         $new = clone $this;
         $new->Type = $Type;
@@ -228,18 +230,18 @@ class SysInfoDocument
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem
      */
-    public function getOperatingSystems()
+    public function getOperatingSystems() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem
     {
         return $this->OperatingSystems;
     }
 
     /**
-     * @param array $OperatingSystems
-     * @return SysInfoDocument
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem $OperatingSystems
+     * @return static
      */
-    public function withOperatingSystems($OperatingSystems)
+    public function withOperatingSystems(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem $OperatingSystems) : static
     {
         $new = clone $this;
         $new->OperatingSystems = $OperatingSystems;
@@ -248,18 +250,18 @@ class SysInfoDocument
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage
      */
-    public function getLanguages()
+    public function getLanguages() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage
     {
         return $this->Languages;
     }
 
     /**
-     * @param array $Languages
-     * @return SysInfoDocument
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage $Languages
+     * @return static
      */
-    public function withLanguages($Languages)
+    public function withLanguages(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage $Languages) : static
     {
         $new = clone $this;
         $new->Languages = $Languages;
@@ -268,18 +270,18 @@ class SysInfoDocument
     }
 
     /**
-     * @return DateTimeInterface
+     * @return \DateTimeInterface
      */
-    public function getDocumentDate()
+    public function getDocumentDate() : \DateTimeInterface
     {
         return $this->DocumentDate;
     }
 
     /**
-     * @param DateTimeInterface $DocumentDate
-     * @return SysInfoDocument
+     * @param \DateTimeInterface $DocumentDate
+     * @return static
      */
-    public function withDocumentDate($DocumentDate)
+    public function withDocumentDate(\DateTimeInterface $DocumentDate) : static
     {
         $new = clone $this;
         $new->DocumentDate = $DocumentDate;
@@ -290,16 +292,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getVersion()
+    public function getVersion() : string
     {
         return $this->Version;
     }
 
     /**
      * @param string $Version
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withVersion($Version)
+    public function withVersion(string $Version) : static
     {
         $new = clone $this;
         $new->Version = $Version;
@@ -308,18 +310,38 @@ class SysInfoDocument
     }
 
     /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion
+     */
+    public function getSubversions() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion
+    {
+        return $this->Subversions;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion $Subversions
+     * @return static
+     */
+    public function withSubversions(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion $Subversions) : static
+    {
+        $new = clone $this;
+        $new->Subversions = $Subversions;
+
+        return $new;
+    }
+
+    /**
      * @return string
      */
-    public function getMatchCode()
+    public function getMatchCode() : string
     {
         return $this->MatchCode;
     }
 
     /**
      * @param string $MatchCode
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withMatchCode($MatchCode)
+    public function withMatchCode(string $MatchCode) : static
     {
         $new = clone $this;
         $new->MatchCode = $MatchCode;
@@ -330,16 +352,16 @@ class SysInfoDocument
     /**
      * @return int
      */
-    public function getRelease()
+    public function getRelease() : int
     {
         return $this->Release;
     }
 
     /**
      * @param int $Release
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withRelease($Release)
+    public function withRelease(int $Release) : static
     {
         $new = clone $this;
         $new->Release = $Release;
@@ -350,16 +372,16 @@ class SysInfoDocument
     /**
      * @return bool
      */
-    public function getRegisteredDownload()
+    public function getRegisteredDownload() : bool
     {
         return $this->RegisteredDownload;
     }
 
     /**
      * @param bool $RegisteredDownload
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withRegisteredDownload($RegisteredDownload)
+    public function withRegisteredDownload(bool $RegisteredDownload) : static
     {
         $new = clone $this;
         $new->RegisteredDownload = $RegisteredDownload;
@@ -370,16 +392,16 @@ class SysInfoDocument
     /**
      * @return bool
      */
-    public function getFindOnlyViaSerialNo()
+    public function getFindOnlyViaSerialNo() : bool
     {
         return $this->FindOnlyViaSerialNo;
     }
 
     /**
      * @param bool $FindOnlyViaSerialNo
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withFindOnlyViaSerialNo($FindOnlyViaSerialNo)
+    public function withFindOnlyViaSerialNo(bool $FindOnlyViaSerialNo) : static
     {
         $new = clone $this;
         $new->FindOnlyViaSerialNo = $FindOnlyViaSerialNo;
@@ -390,16 +412,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getLongDescription()
+    public function getLongDescription() : string
     {
         return $this->LongDescription;
     }
 
     /**
      * @param string $LongDescription
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withLongDescription($LongDescription)
+    public function withLongDescription(string $LongDescription) : static
     {
         $new = clone $this;
         $new->LongDescription = $LongDescription;
@@ -408,18 +430,18 @@ class SysInfoDocument
     }
 
     /**
-     * @return DateTimeInterface
+     * @return \DateTimeInterface
      */
-    public function getMinDate()
+    public function getMinDate() : \DateTimeInterface
     {
         return $this->MinDate;
     }
 
     /**
-     * @param DateTimeInterface $MinDate
-     * @return SysInfoDocument
+     * @param \DateTimeInterface $MinDate
+     * @return static
      */
-    public function withMinDate($MinDate)
+    public function withMinDate(\DateTimeInterface $MinDate) : static
     {
         $new = clone $this;
         $new->MinDate = $MinDate;
@@ -428,18 +450,18 @@ class SysInfoDocument
     }
 
     /**
-     * @return DateTimeInterface
+     * @return \DateTimeInterface
      */
-    public function getMaxDate()
+    public function getMaxDate() : \DateTimeInterface
     {
         return $this->MaxDate;
     }
 
     /**
-     * @param DateTimeInterface $MaxDate
-     * @return SysInfoDocument
+     * @param \DateTimeInterface $MaxDate
+     * @return static
      */
-    public function withMaxDate($MaxDate)
+    public function withMaxDate(\DateTimeInterface $MaxDate) : static
     {
         $new = clone $this;
         $new->MaxDate = $MaxDate;
@@ -448,18 +470,18 @@ class SysInfoDocument
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink
      */
-    public function getLinks()
+    public function getLinks() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink
     {
         return $this->Links;
     }
 
     /**
-     * @param array $Links
-     * @return SysInfoDocument
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink $Links
+     * @return static
      */
-    public function withLinks($Links)
+    public function withLinks(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink $Links) : static
     {
         $new = clone $this;
         $new->Links = $Links;
@@ -470,16 +492,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getFaultText()
+    public function getFaultText() : string
     {
         return $this->FaultText;
     }
 
     /**
      * @param string $FaultText
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withFaultText($FaultText)
+    public function withFaultText(string $FaultText) : static
     {
         $new = clone $this;
         $new->FaultText = $FaultText;
@@ -490,16 +512,16 @@ class SysInfoDocument
     /**
      * @return string
      */
-    public function getSolutionText()
+    public function getSolutionText() : string
     {
         return $this->SolutionText;
     }
 
     /**
      * @param string $SolutionText
-     * @return SysInfoDocument
+     * @return static
      */
-    public function withSolutionText($SolutionText)
+    public function withSolutionText(string $SolutionText) : static
     {
         $new = clone $this;
         $new->SolutionText = $SolutionText;
@@ -507,3 +529,4 @@ class SysInfoDocument
         return $new;
     }
 }
+

--- a/src/Client/Type/SysInfoLanguage.php
+++ b/src/Client/Type/SysInfoLanguage.php
@@ -4,45 +4,44 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 class SysInfoLanguage
 {
+    /**
+     * @var int
+     */
+    private int $Id;
 
     /**
      * @var int
      */
-    private $Id;
-
-    /**
-     * @var int
-     */
-    private $ParentId;
+    private int $ParentId;
 
     /**
      * @var string
      */
-    private $Description;
+    private string $Description;
 
     /**
      * @var string
      */
-    private $Code;
+    private string $Code;
 
     /**
      * @var int
      */
-    private $SortOrder;
+    private int $SortOrder;
 
     /**
      * @return int
      */
-    public function getId()
+    public function getId() : int
     {
         return $this->Id;
     }
 
     /**
      * @param int $Id
-     * @return SysInfoLanguage
+     * @return static
      */
-    public function withId($Id)
+    public function withId(int $Id) : static
     {
         $new = clone $this;
         $new->Id = $Id;
@@ -53,16 +52,16 @@ class SysInfoLanguage
     /**
      * @return int
      */
-    public function getParentId()
+    public function getParentId() : int
     {
         return $this->ParentId;
     }
 
     /**
      * @param int $ParentId
-     * @return SysInfoLanguage
+     * @return static
      */
-    public function withParentId($ParentId)
+    public function withParentId(int $ParentId) : static
     {
         $new = clone $this;
         $new->ParentId = $ParentId;
@@ -73,16 +72,16 @@ class SysInfoLanguage
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->Description;
     }
 
     /**
      * @param string $Description
-     * @return SysInfoLanguage
+     * @return static
      */
-    public function withDescription($Description)
+    public function withDescription(string $Description) : static
     {
         $new = clone $this;
         $new->Description = $Description;
@@ -93,16 +92,16 @@ class SysInfoLanguage
     /**
      * @return string
      */
-    public function getCode()
+    public function getCode() : string
     {
         return $this->Code;
     }
 
     /**
      * @param string $Code
-     * @return SysInfoLanguage
+     * @return static
      */
-    public function withCode($Code)
+    public function withCode(string $Code) : static
     {
         $new = clone $this;
         $new->Code = $Code;
@@ -113,16 +112,16 @@ class SysInfoLanguage
     /**
      * @return int
      */
-    public function getSortOrder()
+    public function getSortOrder() : int
     {
         return $this->SortOrder;
     }
 
     /**
      * @param int $SortOrder
-     * @return SysInfoLanguage
+     * @return static
      */
-    public function withSortOrder($SortOrder)
+    public function withSortOrder(int $SortOrder) : static
     {
         $new = clone $this;
         $new->SortOrder = $SortOrder;
@@ -130,3 +129,4 @@ class SysInfoLanguage
         return $new;
     }
 }
+

--- a/src/Client/Type/SysInfoLink.php
+++ b/src/Client/Type/SysInfoLink.php
@@ -4,50 +4,49 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 class SysInfoLink
 {
+    /**
+     * @var int
+     */
+    private int $Id;
+
+    /**
+     * @var string
+     */
+    private string $NavID;
 
     /**
      * @var int
      */
-    private $Id;
+    private int $ParentId;
 
     /**
      * @var string
      */
-    private $NavID;
-
-    /**
-     * @var int
-     */
-    private $ParentId;
+    private string $Description;
 
     /**
      * @var string
      */
-    private $Description;
-
-    /**
-     * @var string
-     */
-    private $URL;
+    private string $URL;
 
     /**
      * @var bool
      */
-    private $RegisteredDownload;
+    private bool $RegisteredDownload;
 
     /**
      * @return int
      */
-    public function getId()
+    public function getId() : int
     {
         return $this->Id;
     }
 
     /**
      * @param int $Id
-     * @return SysInfoLink
+     * @return static
      */
-    public function withId($Id)
+    public function withId(int $Id) : static
     {
         $new = clone $this;
         $new->Id = $Id;
@@ -58,16 +57,16 @@ class SysInfoLink
     /**
      * @return string
      */
-    public function getNavID()
+    public function getNavID() : string
     {
         return $this->NavID;
     }
 
     /**
      * @param string $NavID
-     * @return SysInfoLink
+     * @return static
      */
-    public function withNavID($NavID)
+    public function withNavID(string $NavID) : static
     {
         $new = clone $this;
         $new->NavID = $NavID;
@@ -78,16 +77,16 @@ class SysInfoLink
     /**
      * @return int
      */
-    public function getParentId()
+    public function getParentId() : int
     {
         return $this->ParentId;
     }
 
     /**
      * @param int $ParentId
-     * @return SysInfoLink
+     * @return static
      */
-    public function withParentId($ParentId)
+    public function withParentId(int $ParentId) : static
     {
         $new = clone $this;
         $new->ParentId = $ParentId;
@@ -98,16 +97,16 @@ class SysInfoLink
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->Description;
     }
 
     /**
      * @param string $Description
-     * @return SysInfoLink
+     * @return static
      */
-    public function withDescription($Description)
+    public function withDescription(string $Description) : static
     {
         $new = clone $this;
         $new->Description = $Description;
@@ -118,16 +117,16 @@ class SysInfoLink
     /**
      * @return string
      */
-    public function getURL()
+    public function getURL() : string
     {
         return $this->URL;
     }
 
     /**
      * @param string $URL
-     * @return SysInfoLink
+     * @return static
      */
-    public function withURL($URL)
+    public function withURL(string $URL) : static
     {
         $new = clone $this;
         $new->URL = $URL;
@@ -138,16 +137,16 @@ class SysInfoLink
     /**
      * @return bool
      */
-    public function getRegisteredDownload()
+    public function getRegisteredDownload() : bool
     {
         return $this->RegisteredDownload;
     }
 
     /**
      * @param bool $RegisteredDownload
-     * @return SysInfoLink
+     * @return static
      */
-    public function withRegisteredDownload($RegisteredDownload)
+    public function withRegisteredDownload(bool $RegisteredDownload) : static
     {
         $new = clone $this;
         $new->RegisteredDownload = $RegisteredDownload;
@@ -155,3 +154,4 @@ class SysInfoLink
         return $new;
     }
 }
+

--- a/src/Client/Type/SysInfoOperatingSystem.php
+++ b/src/Client/Type/SysInfoOperatingSystem.php
@@ -4,40 +4,39 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 class SysInfoOperatingSystem
 {
+    /**
+     * @var int
+     */
+    private int $Id;
 
     /**
      * @var int
      */
-    private $Id;
-
-    /**
-     * @var int
-     */
-    private $ParentId;
+    private int $ParentId;
 
     /**
      * @var string
      */
-    private $Description;
+    private string $Description;
 
     /**
      * @var int
      */
-    private $SortOrder;
+    private int $SortOrder;
 
     /**
      * @return int
      */
-    public function getId()
+    public function getId() : int
     {
         return $this->Id;
     }
 
     /**
      * @param int $Id
-     * @return SysInfoOperatingSystem
+     * @return static
      */
-    public function withId($Id)
+    public function withId(int $Id) : static
     {
         $new = clone $this;
         $new->Id = $Id;
@@ -48,16 +47,16 @@ class SysInfoOperatingSystem
     /**
      * @return int
      */
-    public function getParentId()
+    public function getParentId() : int
     {
         return $this->ParentId;
     }
 
     /**
      * @param int $ParentId
-     * @return SysInfoOperatingSystem
+     * @return static
      */
-    public function withParentId($ParentId)
+    public function withParentId(int $ParentId) : static
     {
         $new = clone $this;
         $new->ParentId = $ParentId;
@@ -68,16 +67,16 @@ class SysInfoOperatingSystem
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->Description;
     }
 
     /**
      * @param string $Description
-     * @return SysInfoOperatingSystem
+     * @return static
      */
-    public function withDescription($Description)
+    public function withDescription(string $Description) : static
     {
         $new = clone $this;
         $new->Description = $Description;
@@ -88,16 +87,16 @@ class SysInfoOperatingSystem
     /**
      * @return int
      */
-    public function getSortOrder()
+    public function getSortOrder() : int
     {
         return $this->SortOrder;
     }
 
     /**
      * @param int $SortOrder
-     * @return SysInfoOperatingSystem
+     * @return static
      */
-    public function withSortOrder($SortOrder)
+    public function withSortOrder(int $SortOrder) : static
     {
         $new = clone $this;
         $new->SortOrder = $SortOrder;
@@ -105,3 +104,4 @@ class SysInfoOperatingSystem
         return $new;
     }
 }
+

--- a/src/Client/Type/SysInfoProduct.php
+++ b/src/Client/Type/SysInfoProduct.php
@@ -4,45 +4,44 @@ namespace Naugrim\WortmannSoapApi\Client\Type;
 
 class SysInfoProduct
 {
+    /**
+     * @var int
+     */
+    private int $Id;
 
     /**
      * @var int
      */
-    private $Id;
-
-    /**
-     * @var int
-     */
-    private $ParentId;
+    private int $ParentId;
 
     /**
      * @var string
      */
-    private $ProductId;
+    private string $ProductId;
 
     /**
      * @var string
      */
-    private $Description;
+    private string $Description;
 
     /**
-     * @var array
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoDocument
      */
-    private $Documents;
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoDocument $Documents;
 
     /**
      * @return int
      */
-    public function getId()
+    public function getId() : int
     {
         return $this->Id;
     }
 
     /**
      * @param int $Id
-     * @return SysInfoProduct
+     * @return static
      */
-    public function withId($Id)
+    public function withId(int $Id) : static
     {
         $new = clone $this;
         $new->Id = $Id;
@@ -53,16 +52,16 @@ class SysInfoProduct
     /**
      * @return int
      */
-    public function getParentId()
+    public function getParentId() : int
     {
         return $this->ParentId;
     }
 
     /**
      * @param int $ParentId
-     * @return SysInfoProduct
+     * @return static
      */
-    public function withParentId($ParentId)
+    public function withParentId(int $ParentId) : static
     {
         $new = clone $this;
         $new->ParentId = $ParentId;
@@ -73,16 +72,16 @@ class SysInfoProduct
     /**
      * @return string
      */
-    public function getProductId()
+    public function getProductId() : string
     {
         return $this->ProductId;
     }
 
     /**
      * @param string $ProductId
-     * @return SysInfoProduct
+     * @return static
      */
-    public function withProductId($ProductId)
+    public function withProductId(string $ProductId) : static
     {
         $new = clone $this;
         $new->ProductId = $ProductId;
@@ -93,16 +92,16 @@ class SysInfoProduct
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription() : string
     {
         return $this->Description;
     }
 
     /**
      * @param string $Description
-     * @return SysInfoProduct
+     * @return static
      */
-    public function withDescription($Description)
+    public function withDescription(string $Description) : static
     {
         $new = clone $this;
         $new->Description = $Description;
@@ -111,18 +110,18 @@ class SysInfoProduct
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoDocument
      */
-    public function getDocuments()
+    public function getDocuments() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoDocument
     {
         return $this->Documents;
     }
 
     /**
-     * @param array $Documents
-     * @return SysInfoProduct
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoDocument $Documents
+     * @return static
      */
-    public function withDocuments($Documents)
+    public function withDocuments(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoDocument $Documents) : static
     {
         $new = clone $this;
         $new->Documents = $Documents;
@@ -130,3 +129,4 @@ class SysInfoProduct
         return $new;
     }
 }
+

--- a/src/Client/Type/SysInfoSubversion.php
+++ b/src/Client/Type/SysInfoSubversion.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Client\Type;
+
+class SysInfoSubversion
+{
+    /**
+     * @var string
+     */
+    private string $Subversion;
+
+    /**
+     * @var string
+     */
+    private string $Description;
+
+    /**
+     * @return string
+     */
+    public function getSubversion() : string
+    {
+        return $this->Subversion;
+    }
+
+    /**
+     * @param string $Subversion
+     * @return static
+     */
+    public function withSubversion(string $Subversion) : static
+    {
+        $new = clone $this;
+        $new->Subversion = $Subversion;
+
+        return $new;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDescription() : string
+    {
+        return $this->Description;
+    }
+
+    /**
+     * @param string $Description
+     * @return static
+     */
+    public function withDescription(string $Description) : static
+    {
+        $new = clone $this;
+        $new->Description = $Description;
+
+        return $new;
+    }
+}
+

--- a/src/Client/Type/TreeListEntry.php
+++ b/src/Client/Type/TreeListEntry.php
@@ -2,69 +2,76 @@
 
 namespace Naugrim\WortmannSoapApi\Client\Type;
 
-use DateTimeInterface;
-
 class TreeListEntry
 {
+    /**
+     * @var int
+     */
+    private int $Type;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem $OperatingSystems;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage $Languages;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink $Links;
+
+    /**
+     * @var string
+     */
+    private string $FaultText;
+
+    /**
+     * @var string
+     */
+    private string $SolutionText;
+
+    /**
+     * @var \DateTimeInterface
+     */
+    private \DateTimeInterface $DocumentDate;
+
+    /**
+     * @var string
+     */
+    private string $Version;
+
+    /**
+     * @var \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion
+     */
+    private \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion $Subversions;
 
     /**
      * @var int
      */
-    private $Type;
-
-    /**
-     * @var array
-     */
-    private $OperatingSystems;
-
-    /**
-     * @var array
-     */
-    private $Languages;
-
-    /**
-     * @var array
-     */
-    private $Links;
+    private int $Release;
 
     /**
      * @var string
      */
-    private $FaultText;
-
-    /**
-     * @var string
-     */
-    private $SolutionText;
-
-    /**
-     * @var DateTimeInterface
-     */
-    private $DocumentDate;
-
-    /**
-     * @var string
-     */
-    private $Version;
-
-    /**
-     * @var string
-     */
-    private $LongDescription;
+    private string $LongDescription;
 
     /**
      * @return int
      */
-    public function getType()
+    public function getType() : int
     {
         return $this->Type;
     }
 
     /**
      * @param int $Type
-     * @return TreeListEntry
+     * @return static
      */
-    public function withType($Type)
+    public function withType(int $Type) : static
     {
         $new = clone $this;
         $new->Type = $Type;
@@ -73,18 +80,18 @@ class TreeListEntry
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem
      */
-    public function getOperatingSystems()
+    public function getOperatingSystems() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem
     {
         return $this->OperatingSystems;
     }
 
     /**
-     * @param array $OperatingSystems
-     * @return TreeListEntry
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem $OperatingSystems
+     * @return static
      */
-    public function withOperatingSystems($OperatingSystems)
+    public function withOperatingSystems(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoOperatingSystem $OperatingSystems) : static
     {
         $new = clone $this;
         $new->OperatingSystems = $OperatingSystems;
@@ -93,18 +100,18 @@ class TreeListEntry
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage
      */
-    public function getLanguages()
+    public function getLanguages() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage
     {
         return $this->Languages;
     }
 
     /**
-     * @param array $Languages
-     * @return TreeListEntry
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage $Languages
+     * @return static
      */
-    public function withLanguages($Languages)
+    public function withLanguages(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLanguage $Languages) : static
     {
         $new = clone $this;
         $new->Languages = $Languages;
@@ -113,18 +120,18 @@ class TreeListEntry
     }
 
     /**
-     * @return array
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink
      */
-    public function getLinks()
+    public function getLinks() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink
     {
         return $this->Links;
     }
 
     /**
-     * @param array $Links
-     * @return TreeListEntry
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink $Links
+     * @return static
      */
-    public function withLinks($Links)
+    public function withLinks(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoLink $Links) : static
     {
         $new = clone $this;
         $new->Links = $Links;
@@ -135,16 +142,16 @@ class TreeListEntry
     /**
      * @return string
      */
-    public function getFaultText()
+    public function getFaultText() : string
     {
         return $this->FaultText;
     }
 
     /**
      * @param string $FaultText
-     * @return TreeListEntry
+     * @return static
      */
-    public function withFaultText($FaultText)
+    public function withFaultText(string $FaultText) : static
     {
         $new = clone $this;
         $new->FaultText = $FaultText;
@@ -155,16 +162,16 @@ class TreeListEntry
     /**
      * @return string
      */
-    public function getSolutionText()
+    public function getSolutionText() : string
     {
         return $this->SolutionText;
     }
 
     /**
      * @param string $SolutionText
-     * @return TreeListEntry
+     * @return static
      */
-    public function withSolutionText($SolutionText)
+    public function withSolutionText(string $SolutionText) : static
     {
         $new = clone $this;
         $new->SolutionText = $SolutionText;
@@ -173,18 +180,18 @@ class TreeListEntry
     }
 
     /**
-     * @return DateTimeInterface
+     * @return \DateTimeInterface
      */
-    public function getDocumentDate()
+    public function getDocumentDate() : \DateTimeInterface
     {
         return $this->DocumentDate;
     }
 
     /**
-     * @param DateTimeInterface $DocumentDate
-     * @return TreeListEntry
+     * @param \DateTimeInterface $DocumentDate
+     * @return static
      */
-    public function withDocumentDate($DocumentDate)
+    public function withDocumentDate(\DateTimeInterface $DocumentDate) : static
     {
         $new = clone $this;
         $new->DocumentDate = $DocumentDate;
@@ -195,16 +202,16 @@ class TreeListEntry
     /**
      * @return string
      */
-    public function getVersion()
+    public function getVersion() : string
     {
         return $this->Version;
     }
 
     /**
      * @param string $Version
-     * @return TreeListEntry
+     * @return static
      */
-    public function withVersion($Version)
+    public function withVersion(string $Version) : static
     {
         $new = clone $this;
         $new->Version = $Version;
@@ -213,18 +220,58 @@ class TreeListEntry
     }
 
     /**
+     * @return \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion
+     */
+    public function getSubversions() : \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion
+    {
+        return $this->Subversions;
+    }
+
+    /**
+     * @param \Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion $Subversions
+     * @return static
+     */
+    public function withSubversions(\Naugrim\WortmannSoapApi\Client\Type\ArrayOfSysInfoSubversion $Subversions) : static
+    {
+        $new = clone $this;
+        $new->Subversions = $Subversions;
+
+        return $new;
+    }
+
+    /**
+     * @return int
+     */
+    public function getRelease() : int
+    {
+        return $this->Release;
+    }
+
+    /**
+     * @param int $Release
+     * @return static
+     */
+    public function withRelease(int $Release) : static
+    {
+        $new = clone $this;
+        $new->Release = $Release;
+
+        return $new;
+    }
+
+    /**
      * @return string
      */
-    public function getLongDescription()
+    public function getLongDescription() : string
     {
         return $this->LongDescription;
     }
 
     /**
      * @param string $LongDescription
-     * @return TreeListEntry
+     * @return static
      */
-    public function withLongDescription($LongDescription)
+    public function withLongDescription(string $LongDescription) : static
     {
         $new = clone $this;
         $new->LongDescription = $LongDescription;
@@ -232,3 +279,4 @@ class TreeListEntry
         return $new;
     }
 }
+

--- a/src/config/wortmann-soap-client.php
+++ b/src/config/wortmann-soap-client.php
@@ -3,15 +3,16 @@
 use Phpro\SoapClient\CodeGenerator\Assembler;
 use Phpro\SoapClient\CodeGenerator\Rules;
 use Phpro\SoapClient\CodeGenerator\Config\Config;
-use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapOptions;
-use Phpro\SoapClient\Soap\Driver\ExtSoap\ExtSoapEngineFactory;
+use Phpro\SoapClient\Soap\DefaultEngineFactory;
+use Soap\ExtSoapEngine\ExtSoapOptions;
+
 
 return Config::create()
-    ->setEngine(ExtSoapEngineFactory::fromOptions(
-        ExtSoapOptions::defaults('https://www.wortmann.de/api/CustomerWebService.asmx?WSDL', [])
-            ->disableWsdlCache()
-    ))
-    ->setTypeDestination('src/Client/Type')
+	->setEngine(DefaultEngineFactory::create(
+		ExtSoapOptions::defaults('https://www.wortmann.de/api/CustomerWebService.asmx?WSDL', [])
+			->disableWsdlCache()
+	))
+	->setTypeDestination('src/Client/Type')
     ->setTypeNamespace('Naugrim\WortmannSoapApi\Client\Type')
     ->setClientDestination('src/Client')
     ->setClientName('ApiClient')

--- a/tests/Feature/Bridge/ApiTest.php
+++ b/tests/Feature/Bridge/ApiTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Tests\Feature\Bridge;
+
+use Mockery;
+use Naugrim\WortmannSoapApi\Bridge\Api;
+use Naugrim\WortmannSoapApi\Client\ApiClient;
+use Naugrim\WortmannSoapApi\Client\Type\CustomerWebServiceProductInfoResponse;
+use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductId;
+use Naugrim\WortmannSoapApi\Client\Type\GetStockAndPriceInformationByProductIdResponse;
+use Naugrim\WortmannSoapApi\Tests\Feature\TestCase;
+use Phpro\SoapClient\Type\ResultInterface;
+
+final class ApiTest extends TestCase{
+
+	public function testRequestReturningResultInterface(): void{
+		config()->set('wortmann-soap-api.username', 'test');
+		config()->set('wortmann-soap-api.password', 'test');
+
+		$api = new Api(['wsdl' => config('wortmann-soap-api.wsdl')]);
+
+		$productInfoResponseMock = Mockery::mock(CustomerWebServiceProductInfoResponse::class);
+		$productInfoResponseMock->shouldReceive('getSuccess')->andReturnTrue(); // @phpstan-ignore-line
+
+		$productIdResponseMock = Mockery::mock(GetStockAndPriceInformationByProductIdResponse::class);
+		$productIdResponseMock->shouldReceive('getGetStockAndPriceInformationByProductIdResult')->andReturn($productInfoResponseMock); // @phpstan-ignore-line
+
+		$clientMock = Mockery::mock(ApiClient::class);
+		$clientMock->shouldReceive('getStockAndPriceInformationByProductId')->andReturn($productIdResponseMock); // @phpstan-ignore-line
+
+		$apiClientProperty = new \ReflectionProperty(Api::class, 'client');
+		$apiClientProperty->setValue($api, $clientMock);
+
+		try{
+			$returnValue = $api->request(GetStockAndPriceInformationByProductId::class, '');
+		}catch(\Throwable){
+			$this->fail();
+		}
+		$this->assertNotNull($returnValue);
+		$this->assertInstanceOf(ResultInterface::class, $returnValue);
+		$this->assertTrue($returnValue->getGetStockAndPriceInformationByProductIdResult()->getSuccess()); // @phpstan-ignore-line
+	}
+}

--- a/tests/Feature/TestCase.php
+++ b/tests/Feature/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Naugrim\WortmannSoapApi\Tests\Feature;
+
+use Naugrim\WortmannSoapApi\Provider\WortmannSoapApiProvider;
+
+class TestCase extends \Orchestra\Testbench\TestCase{
+	public function getPackageProviders($app): array{
+		return [
+			WortmannSoapApiProvider::class
+		];
+	}
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,2 @@
+<?php
+require_once 'vendor/autoload.php';


### PR DESCRIPTION
upgrades minimum PHP version to 8.2 from 8.0

upgrades minimum version of 'phpro/soap-client' to 3.0 drops support for 'phpro/soap-client' in versions below 3.0 because of deprecated features in earlier versions

drops support for 'illuminate/support' in versions below 9.0

adds test

refs #19563 @4h